### PR TITLE
Add LDAP Static Role for Password Rotation

### DIFF
--- a/modules/vault_ldap_secrets/outputs.tf
+++ b/modules/vault_ldap_secrets/outputs.tf
@@ -1,9 +1,24 @@
 output "ldap_secrets_mount_path" {
   description = "The mount path of the LDAP secrets engine"
-  value       =  vault_ldap_secret_backend.ad.path
+  value       = vault_ldap_secret_backend.ad.path
 }
 
 output "ldap_secrets_mount_accessor" {
   description = "The accessor of the LDAP secrets engine mount"
   value       = vault_ldap_secret_backend.ad.accessor
+}
+
+output "static_role_name" {
+  description = "The name of the LDAP static role"
+  value       = vault_ldap_secret_backend_static_role.service_account.role_name
+}
+
+output "static_role_credentials_path" {
+  description = "The full path to read static role credentials from Vault"
+  value       = "${vault_ldap_secret_backend.ad.path}/static-cred/${vault_ldap_secret_backend_static_role.service_account.role_name}"
+}
+
+output "static_role_policy_name" {
+  description = "The name of the policy for reading static role credentials"
+  value       = vault_policy.ldap_static_read.name
 }

--- a/modules/vault_ldap_secrets/variables.tf
+++ b/modules/vault_ldap_secrets/variables.tf
@@ -32,3 +32,21 @@ variable "active_directory_domain" {
   type        = string
   default     = "mydomain.local"
 }
+
+variable "static_role_name" {
+  description = "Name of the static role for password rotation"
+  type        = string
+  default     = "demo-service-account"
+}
+
+variable "static_role_username" {
+  description = "AD username for the static role (without domain)"
+  type        = string
+  default     = "vault-demo"
+}
+
+variable "static_role_rotation_period" {
+  description = "Password rotation period in seconds (default: 24 hours)"
+  type        = number
+  default     = 86400
+}


### PR DESCRIPTION
## Summary
Implements LDAP static role configuration in the vault_ldap_secrets module to enable automatic password rotation for Active Directory accounts.

## Changes
- ✅ Added `vault_ldap_secret_backend_static_role` resource for AD password rotation
- ✅ Configured 24-hour rotation period (configurable via variable)
- ✅ Added `vault_policy` for reading static role credentials
- ✅ Added module outputs: role name, credentials path, and policy name
- ✅ Added input variables for role customization

## Testing
- Module code follows Terraform best practices
- Outputs are properly configured for downstream VSO integration
- Policy grants minimum required permissions

## Related Issues
Closes #1

## Next Steps
This PR must be merged before working on #3 (VSO LDAP Credentials Integration)