### PR TITLE
Add Python Web Application for LDAP Credentials Display

### DIFF
--- a/python-app/.dockerignore
+++ b/python-app/.dockerignore
@@ -1,0 +1,15 @@
+__pycache__
+*.pyc
+*.pyo
+*.pyd
+.Python
+*.so
+*.egg
+*.egg-info
+dist
+build
+.git
+.gitignore
+README.md
+.DS_Store
+*.md

--- a/python-app/Dockerfile
+++ b/python-app/Dockerfile
@@ -1,0 +1,37 @@
+# Multi-stage build for smaller final image
+FROM python:3.11-slim AS builder
+
+WORKDIR /app
+
+# Install dependencies
+COPY requirements.txt .
+RUN pip install --no-cache-dir --user -r requirements.txt
+
+# Final stage
+FROM python:3.11-slim
+
+# Create non-root user for security
+RUN useradd -m -u 1000 appuser
+
+WORKDIR /app
+
+# Copy dependencies from builder
+COPY --from=builder /root/.local /home/appuser/.local
+
+# Copy application code
+COPY app.py .
+
+# Set ownership
+RUN chown -R appuser:appuser /app
+
+# Switch to non-root user
+USER appuser
+
+# Add local bin to PATH
+ENV PATH=/home/appuser/.local/bin:$PATH
+
+# Expose port 8080
+EXPOSE 8080
+
+# Run the application
+CMD ["python", "app.py"]

--- a/python-app/README.md
+++ b/python-app/README.md
@@ -1,0 +1,71 @@
+# Vault LDAP Credentials Display Application
+
+A simple Python Flask web application that displays LDAP credentials delivered by HashiCorp Vault Secrets Operator.
+
+## Features
+
+- Displays LDAP credentials (username, password, DN) from environment variables
+- Clean, responsive web interface
+- Health check endpoint for Kubernetes probes
+- Runs as non-root user for security
+- Lightweight Docker image based on Python 3.11-slim
+
+## Environment Variables
+
+The application expects the following environment variables to be set (typically injected by Vault Secrets Operator):
+
+- `LDAP_USERNAME` - The LDAP username
+- `LDAP_PASSWORD` - The current LDAP password (rotated by Vault)
+- `LDAP_DN` - The distinguished name for the LDAP account
+- `LDAP_LAST_VAULT_PASSWORD` - The last Vault password (for tracking rotations)
+
+## Running Locally
+
+```bash
+# Install dependencies
+pip install -r requirements.txt
+
+# Set environment variables
+export LDAP_USERNAME="demo-user"
+export LDAP_PASSWORD="demo-password"
+export LDAP_DN="CN=demo-user,CN=Users,DC=mydomain,DC=local"
+export LDAP_LAST_VAULT_PASSWORD="previous-password"
+
+# Run the application
+python app.py
+```
+
+Visit http://localhost:8080 to view the application.
+
+## Building the Docker Image
+
+```bash
+docker build -t vault-ldap-demo:latest .
+```
+
+## Running with Docker
+
+```bash
+docker run -p 8080:8080 \
+  -e LDAP_USERNAME="demo-user" \
+  -e LDAP_PASSWORD="demo-password" \
+  -e LDAP_DN="CN=demo-user,CN=Users,DC=mydomain,DC=local" \
+  -e LDAP_LAST_VAULT_PASSWORD="previous-password" \
+  vault-ldap-demo:latest
+```
+
+## Kubernetes Deployment
+
+This application is designed to be deployed on Kubernetes with Vault Secrets Operator managing the LDAP credentials. See the `kube2` module in the parent Terraform stack for the Kubernetes deployment configuration.
+
+## Endpoints
+
+- `/` - Main page displaying LDAP credentials
+- `/health` - Health check endpoint (returns 200 OK with JSON status)
+
+## Security
+
+- Runs as non-root user (UID 1000)
+- Uses multi-stage Docker build for smaller attack surface
+- No sensitive data is logged
+- Credentials are only read from environment variables (not files)

--- a/python-app/app.py
+++ b/python-app/app.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""
+Simple Flask web application to display LDAP credentials from Vault.
+Credentials are delivered via Vault Secrets Operator and read from environment variables.
+"""
+
+import os
+from datetime import datetime
+from flask import Flask, render_template_string
+
+app = Flask(__name__)
+
+# HTML template for displaying credentials
+HTML_TEMPLATE = """
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Vault LDAP Credentials Demo</title>
+    <style>
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif;
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            min-height: 100vh;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            padding: 20px;
+        }
+        .container {
+            background: white;
+            border-radius: 16px;
+            box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+            max-width: 800px;
+            width: 100%;
+            padding: 40px;
+        }
+        .header {
+            text-align: center;
+            margin-bottom: 40px;
+        }
+        .header h1 {
+            color: #2d3748;
+            font-size: 2.5em;
+            margin-bottom: 10px;
+        }
+        .header p {
+            color: #718096;
+            font-size: 1.1em;
+        }
+        .logo {
+            text-align: center;
+            margin-bottom: 30px;
+        }
+        .logo svg {
+            width: 120px;
+            height: 120px;
+        }
+        .credential-section {
+            background: #f7fafc;
+            border-radius: 8px;
+            padding: 24px;
+            margin-bottom: 20px;
+            border-left: 4px solid #667eea;
+        }
+        .credential-label {
+            color: #4a5568;
+            font-size: 0.875em;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            margin-bottom: 8px;
+        }
+        .credential-value {
+            color: #2d3748;
+            font-size: 1.25em;
+            font-family: 'Courier New', monospace;
+            background: white;
+            padding: 12px;
+            border-radius: 4px;
+            word-break: break-all;
+        }
+        .info-box {
+            background: #ebf8ff;
+            border-left: 4px solid #4299e1;
+            border-radius: 8px;
+            padding: 16px;
+            margin-top: 24px;
+        }
+        .info-box p {
+            color: #2c5282;
+            font-size: 0.95em;
+            line-height: 1.6;
+        }
+        .footer {
+            text-align: center;
+            margin-top: 32px;
+            padding-top: 24px;
+            border-top: 1px solid #e2e8f0;
+        }
+        .footer a {
+            color: #667eea;
+            text-decoration: none;
+            font-weight: 500;
+        }
+        .footer a:hover {
+            text-decoration: underline;
+        }
+        .timestamp {
+            color: #718096;
+            font-size: 0.875em;
+            margin-top: 8px;
+        }
+        .status-badge {
+            display: inline-block;
+            background: #48bb78;
+            color: white;
+            padding: 4px 12px;
+            border-radius: 12px;
+            font-size: 0.875em;
+            font-weight: 600;
+            margin-left: 8px;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="logo">
+            <svg viewBox="0 0 256 256" xmlns="http://www.w3.org/2000/svg">
+                <rect fill="#000000" width="256" height="256" rx="24"/>
+                <path fill="#FFFFFF" d="M128 40l96 55.5v111L128 262l-96-55.5v-111L128 40z"/>
+                <path fill="#FFD814" d="M128 80l-64 37v74l64 37 64-37v-74l-64-37z"/>
+                <path fill="#000000" d="M128 100l-48 28v56l48 28 48-28v-56l-48-28z"/>
+            </svg>
+        </div>
+        
+        <div class="header">
+            <h1>Vault LDAP Credentials <span class="status-badge">LIVE</span></h1>
+            <p>Credentials managed by HashiCorp Vault with automatic rotation</p>
+        </div>
+
+        <div class="credential-section">
+            <div class="credential-label">Username</div>
+            <div class="credential-value">{{ username }}</div>
+        </div>
+
+        <div class="credential-section">
+            <div class="credential-label">Password</div>
+            <div class="credential-value">{{ password }}</div>
+        </div>
+
+        <div class="credential-section">
+            <div class="credential-label">Distinguished Name (DN)</div>
+            <div class="credential-value">{{ dn }}</div>
+        </div>
+
+        <div class="credential-section">
+            <div class="credential-label">Last Vault Password</div>
+            <div class="credential-value">{{ last_vault_password }}</div>
+        </div>
+
+        <div class="info-box">
+            <p>
+                <strong>🔐 How it works:</strong> These credentials are automatically rotated by HashiCorp Vault's 
+                LDAP secrets engine every 24 hours. The Vault Secrets Operator synchronizes the rotated credentials 
+                to Kubernetes secrets, which are then injected into this application as environment variables. 
+                When credentials rotate, the application automatically restarts with the new values.
+            </p>
+        </div>
+
+        <div class="timestamp">
+            <strong>Page loaded:</strong> {{ current_time }}
+        </div>
+
+        <div class="footer">
+            <p>
+                Powered by 
+                <a href="https://developer.hashicorp.com/vault" target="_blank">HashiCorp Vault</a> + 
+                <a href="https://developer.hashicorp.com/vault/docs/platform/k8s/vso" target="_blank">Vault Secrets Operator</a>
+            </p>
+        </div>
+    </div>
+</body>
+</html>
+"""
+
+
+@app.route('/')
+def index():
+    """Display LDAP credentials from environment variables."""
+    credentials = {
+        'username': os.getenv('LDAP_USERNAME', 'Not configured'),
+        'password': os.getenv('LDAP_PASSWORD', 'Not configured'),
+        'dn': os.getenv('LDAP_DN', 'Not configured'),
+        'last_vault_password': os.getenv('LDAP_LAST_VAULT_PASSWORD', 'Not configured'),
+        'current_time': datetime.now().strftime('%Y-%m-%d %H:%M:%S UTC')
+    }
+    return render_template_string(HTML_TEMPLATE, **credentials)
+
+
+@app.route('/health')
+def health():
+    """Health check endpoint for Kubernetes liveness/readiness probes."""
+    return {'status': 'healthy', 'timestamp': datetime.now().isoformat()}, 200
+
+
+if __name__ == '__main__':
+    # Run on port 8080 to match existing Go app configuration
+    app.run(host='0.0.0.0', port=8080, debug=False)

--- a/python-app/requirements.txt
+++ b/python-app/requirements.txt
@@ -1,0 +1,2 @@
+Flask==3.1.0
+Werkzeug==3.1.3


### PR DESCRIPTION
## Summary
Creates a Python Flask web application to display LDAP credentials delivered by Vault Secrets Operator.

## Changes
- ✅ Created Flask web application with clean, responsive UI
- ✅ Reads LDAP credentials from environment variables
- ✅ Displays username, password, DN, and last Vault password
- ✅ Health check endpoint at `/health` for Kubernetes probes
- ✅ Multi-stage Dockerfile for optimized image size
- ✅ Runs as non-root user (UID 1000) for security
- ✅ Built and published Docker image: `ghcr.io/andybaran/vault-ldap-demo:v1.0.0`

## Docker Image
- **Registry:** GitHub Container Registry (GHCR)
- **Image:** `ghcr.io/andybaran/vault-ldap-demo:v1.0.0`
- **Tags:** `v1.0.0`, `latest`
- **Size:** ~65MB (based on python:3.11-slim)
- **Security:** Non-root user, minimal dependencies

## Environment Variables
The app expects these environment variables (provided by VSO):
- `LDAP_USERNAME` - LDAP username
- `LDAP_PASSWORD` - Current rotated password
- `LDAP_DN` - Distinguished name
- `LDAP_LAST_VAULT_PASSWORD` - Previous password

## Related Issues
Closes #2

## Next Steps
This PR can be merged independently. Issue #3 will integrate this app with VSO and the kube2 module.