### PR TITLE
Add VSO Integration for LDAP Credentials Delivery

### DIFF
--- a/modules/kube2/4_ldap_app.tf
+++ b/modules/kube2/4_ldap_app.tf
@@ -1,0 +1,209 @@
+# LDAP Credentials Application with Vault Secrets Operator
+# This deployment demonstrates LDAP static role credentials delivered via VSO
+
+locals {
+  ldap_app_name          = "ldap-credentials-app"
+  ldap_app_secret_name   = "ldap-credentials"
+  ldap_app_image         = "ghcr.io/andybaran/vault-ldap-demo:v1.0.0"
+}
+
+# VaultStaticSecret CR for LDAP credentials
+# Reference: https://developer.hashicorp.com/vault/docs/platform/k8s/vso/api-reference#vaultstaticsecret
+resource "kubernetes_manifest" "vault_ldap_secret" {
+  manifest = yamldecode(<<-EOF
+apiVersion: secrets.hashicorp.com/v1beta1
+kind: VaultStaticSecret
+metadata:
+  name: ${local.ldap_app_name}
+  namespace: ${var.kube_namespace}
+spec:
+  type: ldap
+  mount: ${var.ldap_mount_path}
+  path: static-cred/${var.ldap_static_role_name}
+  destination:
+    name: ${local.ldap_app_secret_name}
+    create: true
+  refreshAfter: 30s
+  vaultAuthRef: default
+  rolloutRestartTargets:
+    - kind: Deployment
+      name: ${local.ldap_app_name}
+EOF
+  )
+}
+
+# Deployment for LDAP credentials display application
+resource "kubernetes_deployment_v1" "ldap_app" {
+  depends_on = [
+    kubernetes_manifest.vault_ldap_secret,
+  ]
+
+  metadata {
+    name      = local.ldap_app_name
+    namespace = var.kube_namespace
+    labels = {
+      app = local.ldap_app_name
+    }
+  }
+
+  spec {
+    replicas = 2
+
+    strategy {
+      type = "RollingUpdate"
+      rolling_update {
+        max_unavailable = 1
+        max_surge       = 1
+      }
+    }
+
+    selector {
+      match_labels = {
+        app = local.ldap_app_name
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          app = local.ldap_app_name
+        }
+      }
+
+      spec {
+        container {
+          name  = local.ldap_app_name
+          image = local.ldap_app_image
+
+          port {
+            container_port = 8080
+            name           = "http"
+          }
+
+          # Resource limits for demo purposes
+          resources {
+            limits = {
+              cpu    = "200m"
+              memory = "256Mi"
+            }
+            requests = {
+              cpu    = "100m"
+              memory = "128Mi"
+            }
+          }
+
+          # Liveness probe
+          liveness_probe {
+            http_get {
+              path   = "/health"
+              port   = 8080
+              scheme = "HTTP"
+            }
+            initial_delay_seconds = 10
+            period_seconds        = 10
+            timeout_seconds       = 5
+            failure_threshold     = 3
+          }
+
+          # Readiness probe
+          readiness_probe {
+            http_get {
+              path   = "/health"
+              port   = 8080
+              scheme = "HTTP"
+            }
+            initial_delay_seconds = 5
+            period_seconds        = 5
+            timeout_seconds       = 3
+            failure_threshold     = 3
+          }
+
+          # Environment variables from LDAP secret
+          # VSO syncs these from Vault LDAP static role
+          env {
+            name = "LDAP_USERNAME"
+            value_from {
+              secret_key_ref {
+                name = local.ldap_app_secret_name
+                key  = "username"
+              }
+            }
+          }
+
+          env {
+            name = "LDAP_PASSWORD"
+            value_from {
+              secret_key_ref {
+                name = local.ldap_app_secret_name
+                key  = "password"
+              }
+            }
+          }
+
+          env {
+            name = "LDAP_DN"
+            value_from {
+              secret_key_ref {
+                name = local.ldap_app_secret_name
+                key  = "distinguished_names"
+              }
+            }
+          }
+
+          env {
+            name = "LDAP_LAST_VAULT_PASSWORD"
+            value_from {
+              secret_key_ref {
+                name = local.ldap_app_secret_name
+                key  = "last_vault_rotation"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  lifecycle {
+    ignore_changes = [
+      spec[0].template[0].metadata[0].annotations
+    ]
+  }
+}
+
+# Service for LDAP credentials application
+resource "kubernetes_service_v1" "ldap_app" {
+  metadata {
+    name      = local.ldap_app_name
+    namespace = var.kube_namespace
+    labels = {
+      app = local.ldap_app_name
+    }
+  }
+
+  spec {
+    type = "LoadBalancer"
+
+    port {
+      name        = "http"
+      port        = 80
+      target_port = 8080
+      protocol    = "TCP"
+    }
+
+    selector = {
+      app = local.ldap_app_name
+    }
+  }
+}
+
+# Output the service information
+output "ldap_app_service_name" {
+  description = "Name of the LDAP credentials app service"
+  value       = kubernetes_service_v1.ldap_app.metadata[0].name
+}
+
+output "ldap_app_service_type" {
+  description = "Type of the LDAP credentials app service"
+  value       = kubernetes_service_v1.ldap_app.spec[0].type
+}

--- a/modules/kube2/variables.tf
+++ b/modules/kube2/variables.tf
@@ -9,3 +9,15 @@ variable "vault_mount_credentials_path" {
   type        = string
   default     = ""
 }
+
+variable "ldap_mount_path" {
+  description = "The Vault LDAP secrets engine mount path"
+  type        = string
+  default     = "ldap"
+}
+
+variable "ldap_static_role_name" {
+  description = "The name of the LDAP static role in Vault"
+  type        = string
+  default     = "demo-service-account"
+}


### PR DESCRIPTION
## Summary
Configures Vault Secrets Operator to sync LDAP static role credentials from Vault to Kubernetes and deliver them to the Python application.

## Changes
- ✅ Created `VaultStaticSecret` CR for LDAP credentials synchronization
- ✅ Deployed Python Flask app (`ghcr.io/andybaran/vault-ldap-demo:v1.0.0`)
- ✅ Configured environment variables from synced LDAP secrets
- ✅ Added rollout restart configuration for automatic pod updates
- ✅ Exposed app via LoadBalancer service on port 80
- ✅ Configured health/readiness probes
- ✅ Added module variables for LDAP configuration

## Technical Details
- **VaultStaticSecret Type:** `ldap`
- **Vault Path:** `<ldap_mount_path>/static-cred/<role_name>`
- **Refresh Interval:** 30 seconds
- **Replicas:** 2 for high availability

## Related Issues
Closes #3