### PR TITLE
Fix null template interpolation error in ldap_app_access_info output

### DIFF
--- a/components.tfcomponent.hcl
+++ b/components.tfcomponent.hcl
@@ -222,7 +222,7 @@ output "ldap_app_service_name" {
 
 output "ldap_app_access_info" {
   description = "Access information for the LDAP credentials application"
-  value       = "LDAP credentials app is exposed via LoadBalancer. Use 'kubectl get svc ${component.kube2.ldap_app_service_name} -n ${component.kube1.kube_namespace}' to get the external IP/hostname."
+  value       = component.kube2.ldap_app_service_name != null ? "LDAP credentials app is exposed via LoadBalancer. Use 'kubectl get svc ${component.kube2.ldap_app_service_name} -n ${component.kube1.kube_namespace}' to get the external IP/hostname." : "LDAP app service not yet available"
   type        = string
 }
 


### PR DESCRIPTION
## Problem
During `terraform apply`, the following error occurred:
```
Error: Invalid template interpolation value
The expression result is null. Cannot include a null value in a string template.
on components.tfcomponent.hcl line 225
```

## Solution
Added a conditional check to handle null values in `component.kube2.ldap_app_service_name`:
- If the service name is available, display the full access instructions
- If null, display a fallback message instead of causing an error

## Changes
- Modified `components.tfcomponent.hcl` output `ldap_app_access_info` to use conditional expression
- Prevents template interpolation errors during apply phase

## Testing
- Successfully runs `terraform apply` without template interpolation errors