### PR TITLE
Convert VaultStaticSecret to VaultDynamicSecret for LDAP credentials

### DIFF
--- a/modules/kube2/4_ldap_app.tf
+++ b/modules/kube2/4_ldap_app.tf
@@ -7,26 +7,25 @@ locals {
   ldap_app_image         = "ghcr.io/andybaran/vault-ldap-demo:v1.0.0"
 }
 
-# VaultStaticSecret CR for LDAP credentials
-# Reference: https://developer.hashicorp.com/vault/docs/platform/k8s/vso/api-reference#vaultstaticsecret
+# VaultDynamicSecret CR for LDAP credentials
+# Reference: https://developer.hashicorp.com/vault/docs/platform/k8s/vso/api-reference#vaultdynamicsecret
 resource "kubernetes_manifest" "vault_ldap_secret" {
   manifest = {
     apiVersion = "secrets.hashicorp.com/v1beta1"
-    kind       = "VaultStaticSecret"
+    kind       = "VaultDynamicSecret"
     metadata = {
       name      = local.ldap_app_name
       namespace = var.kube_namespace
     }
     spec = {
-      type  = "ldap"
       mount = var.ldap_mount_path
       path  = "static-cred/${var.ldap_static_role_name}"
       destination = {
         name   = local.ldap_app_secret_name
         create = true
       }
-      refreshAfter = "30s"
-      vaultAuthRef = var.vso_vault_auth_name
+      renewalPercent = 67
+      vaultAuthRef   = var.vso_vault_auth_name
       rolloutRestartTargets = [
         {
           kind = "Deployment"


### PR DESCRIPTION
## Overview
Converts the LDAP credentials resource from `VaultStaticSecret` to `VaultDynamicSecret` in the kube2 module.

## Changes
- **Changed kind**: `VaultStaticSecret` → `VaultDynamicSecret`
- **Removed `type` field**: Not used in VaultDynamicSecret API
- **Updated refresh mechanism**: Replaced `refreshAfter: 30s` with `renewalPercent: 67`
  - Dynamic secrets renew based on lease duration percentage (at 67% of lease lifetime)
  - More appropriate for dynamic credential management
- **Updated documentation reference**: Points to VaultDynamicSecret API reference

## Benefits
- VaultDynamicSecret is better suited for credentials with lease-based lifecycle
- Automatic renewal based on Vault lease duration
- More aligned with Vault's dynamic secrets engine pattern

## Testing
- File: `modules/kube2/4_ldap_app.tf`
- Maintains same path: `static-cred/${var.ldap_static_role_name}`
- Preserves rollout restart behavior for deployment updates