### PR TITLE
Fix Kubernetes Unauthorized error for HCP Terraform

### DIFF
--- a/modules/kube0/1_aws_eks.tf
+++ b/modules/kube0/1_aws_eks.tf
@@ -20,6 +20,22 @@ module "eks" {
   vpc_id                                   = module.vpc.vpc_id
   subnet_ids                               = module.vpc.private_subnets
 
+  # Grant admin access to additional IAM principals (e.g., HCP Terraform execution role)
+  access_entries = {
+    hcp_terraform = {
+      principal_arn = data.aws_caller_identity.current.arn
+      type          = "STANDARD"
+      policy_associations = {
+        admin = {
+          policy_arn = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy"
+          access_scope = {
+            type = "cluster"
+          }
+        }
+      }
+    }
+  }
+
   kms_key_administrators = [
     local.extra_doormat_role,
     data.aws_iam_session_context.current.issuer_arn,

--- a/modules/kube2/4_ldap_app.tf
+++ b/modules/kube2/4_ldap_app.tf
@@ -173,8 +173,11 @@ resource "kubernetes_deployment_v1" "ldap_app" {
 
   lifecycle {
     ignore_changes = [
-      spec[0].template[0].metadata[0].annotations
+      spec[0].template[0].metadata[0].annotations,
+      metadata[0].annotations
     ]
+    # Prevent unnecessary replacement - only replace if critical changes
+    create_before_destroy = true
   }
 }
 


### PR DESCRIPTION
## Related Issue
Fixes #25

## Problem
HCP Terraform fails with "Unauthorized" error when trying to manage Kubernetes deployments:
```
Error: Unauthorized
on modules/kube2/4_ldap_app.tf line 43
```

**Root Cause:**
- HCP Terraform uses a different AWS IAM role/identity than local kubectl
- This IAM role was not granted access to the EKS cluster
- The Kubernetes provider authentication fails because the IAM role doesn't have cluster permissions

## Solution
Added EKS access entries to grant the HCP Terraform execution IAM role cluster admin permissions.

## Changes

### `modules/kube0/1_aws_eks.tf`
Added `access_entries` block to the EKS module:
- Uses `data.aws_caller_identity.current.arn` to dynamically get the executing IAM principal
- Grants `AmazonEKSClusterAdminPolicy` cluster-wide
- This works for both local execution and HCP Terraform

### `modules/kube2/4_ldap_app.tf`
Enhanced lifecycle block:
- Added `metadata[0].annotations` to ignore_changes
- Added `create_before_destroy = true` for safer replacements

## How It Works
1. `data.aws_caller_identity.current.arn` resolves to the IAM role executing Terraform
2. For HCP Terraform, this is the HCP Terraform execution role
3. For local execution, this is your IAM user/role
4. The `access_entries` grants this identity admin access to the cluster
5. Kubernetes provider can now authenticate and manage resources

## Testing
After applying:
1. HCP Terraform should successfully manage Kubernetes resources
2. Deployment updates/replacements should work without Unauthorized errors
3. Local kubectl access remains unchanged

## References
- [EKS Module Access Entries](https://registry.terraform.io/modules/terraform-aws-modules/eks/aws/latest#access_entries)
- [EKS Access Policies](https://docs.aws.amazon.com/eks/latest/userguide/access-policies.html)