### PR TITLE
Fix EKS Access Entry invalid principalArn format

### DIFF
--- a/modules/kube0/1_aws_eks.tf
+++ b/modules/kube0/1_aws_eks.tf
@@ -21,9 +21,10 @@ module "eks" {
   subnet_ids                               = module.vpc.private_subnets
 
   # Grant admin access to additional IAM principals (e.g., HCP Terraform execution role)
+  # Use issuer_arn to get the IAM role ARN, not the assumed role session ARN
   access_entries = {
     hcp_terraform = {
-      principal_arn = data.aws_caller_identity.current.arn
+      principal_arn = data.aws_iam_session_context.current.issuer_arn
       type          = "STANDARD"
       policy_associations = {
         admin = {


### PR DESCRIPTION
## Related Issue
Fixes #27

## Problem
Creating EKS access entry fails with:
```
InvalidParameterException: The principalArn parameter format is not valid
```

The error occurs because we were using an assumed role session ARN:
```
arn:aws:sts::851170382860:assumed-role/aws_andy.baran_test-developer/andy.baran@hashicorp.com
```

## Root Cause
`data.aws_caller_identity.current.arn` returns the **session ARN** when using assumed roles. EKS access entries only accept **IAM role ARNs**.

## Solution
Changed to use `data.aws_iam_session_context.current.issuer_arn` which resolves to the actual IAM role ARN:
```
arn:aws:iam::851170382860:role/aws_andy.baran_test-developer
```

## Changes
### `modules/kube0/1_aws_eks.tf`
```diff
access_entries = {
  hcp_terraform = {
-   principal_arn = data.aws_caller_identity.current.arn
+   principal_arn = data.aws_iam_session_context.current.issuer_arn
```

## Testing
After applying:
1. EKS access entry should be created successfully
2. HCP Terraform should have cluster admin access
3. Kubernetes resources can be managed without Unauthorized errors