### PR TITLE
Remove duplicate EKS access entry

### DIFF
--- a/modules/kube0/1_aws_eks.tf
+++ b/modules/kube0/1_aws_eks.tf
@@ -20,22 +20,9 @@ module "eks" {
   vpc_id                                   = module.vpc.vpc_id
   subnet_ids                               = module.vpc.private_subnets
 
-  # Grant admin access to additional IAM principals (e.g., HCP Terraform execution role)
-  # Use issuer_arn to get the IAM role ARN, not the assumed role session ARN
-  access_entries = {
-    hcp_terraform = {
-      principal_arn = data.aws_iam_session_context.current.issuer_arn
-      type          = "STANDARD"
-      policy_associations = {
-        admin = {
-          policy_arn = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy"
-          access_scope = {
-            type = "cluster"
-          }
-        }
-      }
-    }
-  }
+  # Note: enable_cluster_creator_admin_permissions = true already grants admin
+  # access to the IAM role that creates the cluster. No need for explicit
+  # access_entries for the same role - that would cause a duplicate conflict.
 
   kms_key_administrators = [
     local.extra_doormat_role,


### PR DESCRIPTION
## Related Issue
Fixes #29

## Problem
Creating EKS access entry fails with ResourceInUseException (409 conflict):
```
ResourceInUseException: The specified access entry resource is already in use on this cluster.
```

## Root Cause
The EKS module configuration had both:
1. `enable_cluster_creator_admin_permissions = true`
2. Explicit `access_entries` block for the same IAM role

Since the cluster creator IAM role is the same as `data.aws_iam_session_context.current.issuer_arn`, we were attempting to create a duplicate access entry.

## Solution
Removed the explicit `access_entries` block. The `enable_cluster_creator_admin_permissions = true` setting already provides admin access to the IAM role executing Terraform.

## Changes
### `modules/kube0/1_aws_eks.tf`
- Removed the `access_entries` block (16 lines)
- Added explanatory comment about why it's not needed

## How It Works
When `enable_cluster_creator_admin_permissions = true`:
- EKS automatically creates an access entry for the IAM principal that creates the cluster
- This grants `AmazonEKSClusterAdminPolicy` to that principal
- Since HCP Terraform uses the same IAM role for both creation and subsequent applies, no additional access entry is needed

## Testing
After applying:
1. No ResourceInUseException errors
2. HCP Terraform retains cluster admin access
3. Kubernetes resources can be managed successfully