### PR TITLE
Fix VSO Vault auth - enable local CA JWT validation

### DIFF
--- a/components.tfcomponent.hcl
+++ b/components.tfcomponent.hcl
@@ -117,6 +117,7 @@ component "vault_ldap_secrets" {
     secrets_mount_path      = "ldap"
     active_directory_domain = "mydomain.local"
     kubernetes_host         = component.kube0.cluster_endpoint
+    kubernetes_ca_cert      = component.kube0.kube_cluster_certificate_authority_data
     kube_namespace          = component.kube1.kube_namespace
   }
   providers = {

--- a/modules/vault_ldap_secrets/kubernetes_auth.tf
+++ b/modules/vault_ldap_secrets/kubernetes_auth.tf
@@ -9,12 +9,13 @@ resource "vault_auth_backend" "kubernetes" {
 # Kubernetes auth backend configuration
 # Reference: https://registry.terraform.io/providers/hashicorp/vault/latest/docs/resources/kubernetes_auth_backend_config
 resource "vault_kubernetes_auth_backend_config" "config" {
-  backend         = vault_auth_backend.kubernetes.path
-  kubernetes_host = var.kubernetes_host
+  backend            = vault_auth_backend.kubernetes.path
+  kubernetes_host    = var.kubernetes_host
+  kubernetes_ca_cert = base64decode(var.kubernetes_ca_cert)
   
-  # Use service account token authentication instead of CA cert validation
-  # This is more reliable in EKS/cloud environments and avoids CA cert format issues
-  disable_local_ca_jwt = true
+  # When disable_local_ca_jwt is false, Vault validates JWT tokens locally using the CA cert
+  # This is more reliable than calling the K8s API for token review
+  disable_local_ca_jwt = false
 }
 
 # Kubernetes auth backend role for VSO

--- a/modules/vault_ldap_secrets/variables.tf
+++ b/modules/vault_ldap_secrets/variables.tf
@@ -56,6 +56,11 @@ variable "kubernetes_host" {
   type        = string
 }
 
+variable "kubernetes_ca_cert" {
+  description = "Kubernetes cluster CA certificate (base64 encoded) for Vault auth backend"
+  type        = string
+}
+
 variable "kube_namespace" {
   description = "Kubernetes namespace where VSO is deployed"
   type        = string


### PR DESCRIPTION
## Related Issue
Fixes #31

## Problem
VaultDynamicSecret fails to authenticate to Vault with 403 permission denied:
```
VaultClientConfigError: Failed to get Vault client: Error making API request.
URL: PUT http://.../v1/auth/kubernetes/login
Code: 403. Errors: permission denied
```

## Root Cause Analysis
The Vault kubernetes auth config showed:
```
disable_local_ca_jwt    true
token_reviewer_jwt_set  false
```

When `disable_local_ca_jwt = true`, Vault cannot validate JWT tokens locally and must call the Kubernetes TokenReview API. However, this requires a `token_reviewer_jwt` to be configured - which was not set.

Without either:
1. A local CA cert to validate JWT tokens locally, OR
2. A `token_reviewer_jwt` to call the Kubernetes TokenReview API

Vault cannot validate service account tokens at all, resulting in 403 permission denied.

## Solution
Changed to use local CA JWT validation:
- Set `disable_local_ca_jwt = false`
- Provide the Kubernetes CA certificate
- Vault now validates tokens locally using the CA cert
- No need to configure a `token_reviewer_jwt`

## Changes

### `modules/vault_ldap_secrets/kubernetes_auth.tf`
```diff
resource "vault_kubernetes_auth_backend_config" "config" {
  backend            = vault_auth_backend.kubernetes.path
  kubernetes_host    = var.kubernetes_host
+ kubernetes_ca_cert = base64decode(var.kubernetes_ca_cert)
- disable_local_ca_jwt = true
+ disable_local_ca_jwt = false
}
```

### `modules/vault_ldap_secrets/variables.tf`
- Added `kubernetes_ca_cert` variable

### `components.tfcomponent.hcl`
- Added `kubernetes_ca_cert = component.kube0.kube_cluster_certificate_authority_data`

## Testing
After applying:
1. Vault kubernetes auth config will show `disable_local_ca_jwt = false` and `kubernetes_ca_cert` populated
2. VSO should authenticate successfully
3. VaultDynamicSecret should sync LDAP credentials
4. ldap-credentials-app pods should start without errors

## References
- [Vault Kubernetes Auth Config](https://developer.hashicorp.com/vault/api-docs/auth/kubernetes#configure-method)
- [Vault Kubernetes Auth Troubleshooting](https://developer.hashicorp.com/vault/docs/auth/kubernetes#troubleshooting)