### PR TITLE
Fix LDAP secret key name mismatch

### DIFF
--- a/modules/kube2/4_ldap_app.tf
+++ b/modules/kube2/4_ldap_app.tf
@@ -152,7 +152,7 @@ resource "kubernetes_deployment_v1" "ldap_app" {
             value_from {
               secret_key_ref {
                 name = local.ldap_app_secret_name
-                key  = "distinguished_names"
+                key  = "dn"
               }
             }
           }


### PR DESCRIPTION
## Related Issue
Fixes #35

## Problem
LDAP credentials app pods fail to start with error:
```
Error: couldn't find key distinguished_names in Secret simple-app/ldap-credentials
```

## Root Cause
The deployment environment variable was referencing the wrong secret key name:
- **Expected**: `distinguished_names`
- **Actual**: `dn`

The Vault LDAP static-cred endpoint returns the distinguished name in a key called `dn`, not `distinguished_names`.

## Actual Secret Keys
From Vault LDAP static-cred endpoint:
- `username` ✅
- `password` ✅
- `dn` ✅ (was `distinguished_names`)
- `last_vault_rotation` ✅
- `last_password`
- `rotation_period`
- `ttl`
- `_raw`

## Solution
Changed the `LDAP_DN` environment variable to reference the correct key.

## Changes
### `modules/kube2/4_ldap_app.tf`
```diff
env {
  name = "LDAP_DN"
  value_from {
    secret_key_ref {
      name = local.ldap_app_secret_name
-     key  = "distinguished_names"
+     key  = "dn"
    }
  }
}
```

## Testing
After applying:
1. Pods should start successfully
2. No "couldn't find key" errors
3. Application can access the LDAP distinguished name via `LDAP_DN` environment variable