### PR TITLE
Set imagePullPolicy to Always for LDAP app deployment

### DIFF
--- a/modules/kube2/4_ldap_app.tf
+++ b/modules/kube2/4_ldap_app.tf
@@ -79,8 +79,9 @@ resource "kubernetes_deployment_v1" "ldap_app" {
 
       spec {
         container {
-          name  = local.ldap_app_name
-          image = local.ldap_app_image
+          name              = local.ldap_app_name
+          image             = local.ldap_app_image
+          image_pull_policy = "Always"
 
           port {
             container_port = 8080


### PR DESCRIPTION
## Related Issue
Fixes #39

## Problem
The deployment uses the default `imagePullPolicy` which is `IfNotPresent`. This causes issues when:
- Rebuilding images with the same tag (e.g., v1.0.0)
- Switching image architectures with the same tag
- The image has been updated in the registry but the tag hasn't changed

Kubernetes won't pull the new image if it's already cached locally.

## Solution
Set `imagePullPolicy: Always` to ensure Kubernetes always pulls the latest version from the registry.

## Changes

### `modules/kube2/4_ldap_app.tf`
```diff
spec {
  container {
    name              = local.ldap_app_name
    image             = local.ldap_app_image
+   image_pull_policy = "Always"
  }
}
```

## Impact
- Ensures the AMD64 rebuilt image is pulled
- Pods will always pull the latest image on creation/restart
- Slightly slower pod startup (image pull overhead)
- Guarantees image freshness

## Use Cases This Solves
✅ Just rebuilt the image for AMD64 with same tag (v1.0.0)  
✅ Need to ensure all pods get the new architecture  
✅ Development/testing where images are frequently rebuilt  

## Testing
After applying:
1. Existing pods will continue running
2. New pods will pull the latest image from registry
3. Rolling updates will get the correct AMD64 image