### PR TITLE
Fix empty LDAP credentials - enable initial password rotation

### DIFF
--- a/modules/vault_ldap_secrets/main.tf
+++ b/modules/vault_ldap_secrets/main.tf
@@ -30,8 +30,9 @@ resource "vault_ldap_secret_backend_static_role" "service_account" {
   # Rotate password every 24 hours (86400 seconds)
   rotation_period = var.static_role_rotation_period
 
-  # Skip initial rotation to avoid disrupting the service account immediately
-  skip_import_rotation = true
+  # Allow initial rotation to import the password from AD
+  # This is required for Vault to manage and return the credentials
+  skip_import_rotation = false
 }
 
 # Policy for reading LDAP static credentials


### PR DESCRIPTION
## Related Issue
Fixes #41

## Problem
The python app shows "Not configured" for password and DN values because the Kubernetes secret has empty values for these fields.

## Root Cause Investigation

### 1. Secret Exists But Values Are Empty
```bash
kubectl get secret ldap-credentials -n simple-app -o json | jq '.data | map_values(length)'
{
  "username": 16,    # populated ✅
  "password": 0,     # EMPTY ❌
  "dn": 0            # EMPTY ❌
}
```

### 2. Vault Returns n/a for Credentials
```bash
vault read ldap/static-cred/demo-service-account

Key                    Value
---                    -----
dn                     n/a          ❌
password               n/a          ❌
last_vault_rotation    0001-01-01T00:00:00Z
username               vault-demo   ✅
```

### 3. Root Cause
The static role configuration had:
```hcl
skip_import_rotation = true
```

This prevented Vault from:
- Connecting to Active Directory to import the password
- Performing the initial password rotation
- Storing and returning valid credentials

## Solution
Changed `skip_import_rotation` from `true` to `false`.

### What This Does
1. **On terraform apply**, Vault will:
   - Connect to the Active Directory server
   - Read the current password for the `vault-demo` user
   - Immediately rotate it to a new Vault-managed password
   - Store the credentials

2. **VSO will then**:
   - Read the actual credentials from Vault
   - Sync them to the Kubernetes secret
   - Trigger a deployment rollout restart

3. **Application will**:
   - Receive valid password and DN values
   - Display them on the web page

## Changes

### `modules/vault_ldap_secrets/main.tf`
```diff
resource "vault_ldap_secret_backend_static_role" "service_account" {
  ...
- # Skip initial rotation to avoid disrupting the service account immediately
- skip_import_rotation = true
+ # Allow initial rotation to import the password from AD
+ # This is required for Vault to manage and return the credentials
+ skip_import_rotation = false
}
```

## Prerequisites
⚠️ **Important**: The `vault-demo` user must exist in Active Directory before applying this change.

## Testing
After terraform apply:
1. Wait ~30 seconds for Vault to complete the rotation
2. Check Vault: `vault read ldap/static-cred/demo-service-account`
   - Should show real password (not n/a)
   - Should show DN (not n/a)
3. Check secret: `kubectl get secret ldap-credentials -n simple-app -o json | jq '.data | map_values(length)'`
   - password should have length > 0
   - dn should have length > 0
4. Access the web app - password and DN should display

## Impact
- The `vault-demo` AD user password will be rotated immediately
- If anything is currently using that password, it will break until updated