### PR TITLE
Fix duplicate wait_for_completion attribute in kubernetes_job_v1

### DIFF
--- a/modules/kube1/3_create_ad_user_job.tf
+++ b/modules/kube1/3_create_ad_user_job.tf
@@ -182,8 +182,6 @@ resource "kubernetes_job_v1" "create_ad_user" {
       }
     }
   }
-
-  wait_for_completion = false
 }
 
 # Output the initial password (will be rotated by Vault)


### PR DESCRIPTION
## Related Issue
Fixes #47

## Problem
The `kubernetes_job_v1.create_ad_user` resource had the `wait_for_completion` attribute defined **twice**, causing a Terraform validation error:

```
Error: Attribute redefined
Error: The argument "wait_for_completion" was already set at 
git::https://github.com/andybaran/aws-vault-ldap-k8s.git//modules/kube1/3_create_ad_user_job.tf?ref=bf28b2ba38950e5a7306479e9aaf34edbe3339ce:94,3-22. 
Each argument may be set only once.

on modules/kube1/3_create_ad_user_job.tf line 186, in resource "kubernetes_job_v1" "create_ad_user":
186: wait_for_completion = false
```

### Root Cause
When PR #44 added the dependency chain to ensure the job completes before Vault LDAP secrets engine configuration, `wait_for_completion = true` was added at **line 94**. However, the original resource definition still had `wait_for_completion = false` at **line 186**, creating a duplicate.

## Solution
Removed the duplicate `wait_for_completion = false` at line 186, keeping only the one at line 94 set to `true`.

### Why `true` is Correct
We **want** the job to wait for completion because:
1. The job creates the `vault-demo` Active Directory user
2. Vault LDAP secrets engine needs this user to exist
3. Component dependency chain ensures: Job completes → Vault configures
4. Without `wait_for_completion = true`, Terraform would mark the job as created immediately, and Vault would try to configure the static role before the user exists

## Changes

### Before (Duplicate Attribute)
```hcl
resource "kubernetes_job_v1" "create_ad_user" {
  metadata { ... }
  
  # Line 94
  wait_for_completion = true
  
  timeouts { ... }
  spec { ... }
  
  # Line 186 - DUPLICATE!
  wait_for_completion = false
}
```

### After (Single Attribute)
```hcl
resource "kubernetes_job_v1" "create_ad_user" {
  metadata { ... }
  
  # Line 94 - Only one definition
  wait_for_completion = true
  
  timeouts { ... }
  spec { ... }
}
```

## Verification
Checked that only one `wait_for_completion` attribute exists:
```bash
$ grep -n "wait_for_completion" modules/kube1/3_create_ad_user_job.tf
94:  wait_for_completion = true
```
✅ Only one occurrence

## Testing
After merge:
1. `terraform init` - should succeed
2. `terraform validate` - should succeed without attribute redefinition error
3. `terraform plan` - should succeed
4. `terraform apply` - job will wait for completion before proceeding

## Impact
- **Breaking Changes**: None
- **Behavior Change**: None (intended behavior was already `true`)
- **Dependencies**: Maintains dependency chain from PR #44

## Related PRs
- PR #44 - Added AD user creation job (introduced the intended `wait_for_completion = true`)
- PR #42 - Set `skip_import_rotation = false` (depends on user existing)