### PR TITLE
Fix AD user creation job - read-only filesystem and LDAP connection errors

### DIFF
--- a/modules/kube1/3_create_ad_user_job.tf
+++ b/modules/kube1/3_create_ad_user_job.tf
@@ -49,35 +49,123 @@ resource "kubernetes_config_map_v1" "create_ad_user_ldif" {
       #!/bin/bash
       set -e
       
-      echo "Connecting to LDAP server at ${local.ldap_server}..."
+      LDAP_SERVER="${local.ldap_server}"
+      VAULT_USER="${local.vault_demo_username}"
+      INITIAL_PASSWORD="${local.vault_demo_initial_password}"
+      USER_DN="CN=$VAULT_USER,CN=Users,DC=mydomain,DC=local"
+      MAX_RETRIES=30
+      RETRY_DELAY=10
       
-      # Try to create the user
-      echo "Creating user ${local.vault_demo_username}..."
-      ldapadd -x -H ldap://${local.ldap_server} \
-        -D "$ADMIN_DN" \
-        -w "$ADMIN_PASSWORD" \
-        -f /ldif/create-user.ldif || echo "User may already exist, continuing..."
+      echo "==============================================="
+      echo "AD User Creation Job Starting"
+      echo "LDAP Server: $LDAP_SERVER"
+      echo "User: $VAULT_USER"
+      echo "User DN: $USER_DN"
+      echo "==============================================="
       
-      # Set the password using ldapmodify
+      # Wait for LDAP server to be ready
+      echo "Waiting for LDAP server to be ready..."
+      for i in $(seq 1 $MAX_RETRIES); do
+        if timeout 5 bash -c "echo > /dev/tcp/$LDAP_SERVER/389" 2>/dev/null; then
+          echo "✓ LDAP server is reachable on port 389"
+          break
+        fi
+        
+        if [ $i -eq $MAX_RETRIES ]; then
+          echo "✗ ERROR: LDAP server not reachable after $MAX_RETRIES attempts"
+          echo "Network debugging:"
+          echo "- Testing DNS resolution:"
+          nslookup $LDAP_SERVER || echo "DNS resolution failed"
+          echo "- Testing connectivity:"
+          nc -zv $LDAP_SERVER 389 2>&1 || echo "TCP connection failed"
+          exit 1
+        fi
+        
+        echo "Waiting for LDAP server... (attempt $i/$MAX_RETRIES)"
+        sleep $RETRY_DELAY
+      done
+      
+      # Additional wait for LDAP service to be fully initialized
+      echo "Waiting 10 seconds for LDAP service to fully initialize..."
+      sleep 10
+      
+      # Test LDAP bind before attempting user creation
+      echo "Testing LDAP authentication..."
+      if ! ldapwhoami -x -H ldap://$LDAP_SERVER -D "$ADMIN_DN" -w "$ADMIN_PASSWORD"; then
+        echo "✗ ERROR: LDAP authentication failed"
+        echo "Admin DN: $ADMIN_DN"
+        exit 1
+      fi
+      echo "✓ LDAP authentication successful"
+      
+      # Check if user already exists
+      echo "Checking if user $VAULT_USER already exists..."
+      if ldapsearch -x -H ldap://$LDAP_SERVER \
+          -D "$ADMIN_DN" \
+          -w "$ADMIN_PASSWORD" \
+          -b "$USER_DN" \
+          "(objectClass=*)" dn 2>/dev/null | grep -q "^dn:"; then
+        echo "✓ User $VAULT_USER already exists, skipping creation"
+      else
+        echo "Creating user $VAULT_USER..."
+        if ldapadd -x -H ldap://$LDAP_SERVER \
+            -D "$ADMIN_DN" \
+            -w "$ADMIN_PASSWORD" \
+            -f /ldif/create-user.ldif; then
+          echo "✓ User created successfully"
+        else
+          echo "✗ Failed to create user"
+          exit 1
+        fi
+      fi
+      
+      # Set the password
       echo "Setting initial password..."
-      ldappasswd -x -H ldap://${local.ldap_server} \
-        -D "$ADMIN_DN" \
-        -w "$ADMIN_PASSWORD" \
-        -s "${local.vault_demo_initial_password}" \
-        "CN=${local.vault_demo_username},CN=Users,DC=mydomain,DC=local"
+      if ldappasswd -x -H ldap://$LDAP_SERVER \
+          -D "$ADMIN_DN" \
+          -w "$ADMIN_PASSWORD" \
+          -s "$INITIAL_PASSWORD" \
+          "$USER_DN"; then
+        echo "✓ Password set successfully"
+      else
+        echo "✗ Failed to set password"
+        exit 1
+      fi
       
-      # Enable the account
+      # Enable the account (userAccountControl: 512 = normal account, enabled)
       echo "Enabling the account..."
-      cat <<EOF | ldapmodify -x -H ldap://${local.ldap_server} -D "$ADMIN_DN" -w "$ADMIN_PASSWORD"
-      dn: CN=${local.vault_demo_username},CN=Users,DC=mydomain,DC=local
+      if cat <<EOF | ldapmodify -x -H ldap://$LDAP_SERVER -D "$ADMIN_DN" -w "$ADMIN_PASSWORD"
+      dn: $USER_DN
       changetype: modify
       replace: userAccountControl
       userAccountControl: 512
       EOF
+      then
+        echo "✓ Account enabled successfully"
+      else
+        echo "✗ Failed to enable account"
+        exit 1
+      fi
       
-      echo "User ${local.vault_demo_username} created successfully!"
-      echo "Initial password: ${local.vault_demo_initial_password}"
-      echo "Note: This password will be rotated by Vault on first use."
+      # Verify user was created correctly
+      echo "Verifying user creation..."
+      if ldapsearch -x -H ldap://$LDAP_SERVER \
+          -D "$ADMIN_DN" \
+          -w "$ADMIN_PASSWORD" \
+          -b "$USER_DN" \
+          "(objectClass=*)" sAMAccountName userAccountControl | grep -q "sAMAccountName: $VAULT_USER"; then
+        echo "✓ User verification successful"
+      else
+        echo "⚠ Warning: User verification failed, but continuing"
+      fi
+      
+      echo "==============================================="
+      echo "✓ AD User Creation Job Completed Successfully"
+      echo "User: $VAULT_USER"
+      echo "DN: $USER_DN"
+      echo "Initial password: $INITIAL_PASSWORD"
+      echo "Note: This password will be rotated by Vault"
+      echo "==============================================="
     EOT
   }
 }
@@ -93,10 +181,11 @@ resource "kubernetes_job_v1" "create_ad_user" {
   # This ensures vault_ldap_secrets component waits for the user to exist
   wait_for_completion = true
   
-  # Timeout for job completion (default would be too short)
+  # Timeout for job completion (increased to accommodate retry logic)
+  # Max retries: 30 * 10 seconds = 5 minutes + installation time
   timeouts {
-    create = "5m"
-    update = "5m"
+    create = "10m"
+    update = "10m"
   }
 
   spec {
@@ -120,9 +209,17 @@ resource "kubernetes_job_v1" "create_ad_user" {
           command = ["/bin/bash", "-c"]
           args = [
             <<-EOT
-              apt-get update && apt-get install -y ldap-utils
-              chmod +x /scripts/set-password.sh
-              /scripts/set-password.sh
+              set -e
+              echo "Installing dependencies..."
+              apt-get update -qq
+              apt-get install -y -qq ldap-utils netcat-openbsd dnsutils > /dev/null 2>&1
+              
+              echo "Copying script to writable location..."
+              cp /scripts/set-password.sh /tmp/set-password.sh
+              chmod +x /tmp/set-password.sh
+              
+              echo "Executing AD user creation script..."
+              /tmp/set-password.sh
             EOT
           ]
 


### PR DESCRIPTION
## Related Issue
Fixes #49

## Overview
Fixed two critical issues preventing the `create-ad-user` Kubernetes job from completing successfully.

## Problems

### 1. ❌ Read-only Filesystem Error
```
chmod: changing permissions of '/scripts/set-password.sh': Read-only file system
```

**Root Cause:** ConfigMaps are mounted as read-only by default in Kubernetes. The job tried to `chmod` a script directly from the ConfigMap mount at `/scripts`.

**Solution:** Copy the script to a writable location (`/tmp`) before executing it.

### 2. ❌ LDAP Connection Failures
```
ldap_sasl_bind(SIMPLE): Can't contact LDAP server (-1)
```

**Root Cause:** The job started immediately after the LDAP component deployed, but:
- LDAP server might not be fully initialized
- Network connectivity might not be established yet
- No retry logic to handle timing issues

**Solution:** Implemented comprehensive retry and wait logic with network debugging.

---

## Solutions Implemented

### 🔧 Script Execution Fix
**Before:**
```bash
chmod +x /scripts/set-password.sh  # ❌ Fails - read-only filesystem
/scripts/set-password.sh
```

**After:**
```bash
cp /scripts/set-password.sh /tmp/set-password.sh  # ✅ Copy to writable location
chmod +x /tmp/set-password.sh
/tmp/set-password.sh
```

### 🔄 LDAP Connection Retry Logic
Implemented multi-layer readiness checking:

#### 1. Wait for TCP Port 389
```bash
# Retry up to 30 times (5 minutes total)
for i in 1
2
3
4
5
6
7
8
9
10
11
12
13
14
15
16
17
18
19
20
21
22
23
24
25
26
27
28
29
30; do
  if timeout 5 bash -c "echo > /dev/tcp/$LDAP_SERVER/389"; then
    echo "✓ LDAP server is reachable"
    break
  fi
  sleep 10
done
```

#### 2. Wait for Service Initialization
```bash
# Additional wait for LDAP to fully start
sleep 10
```

#### 3. Test LDAP Authentication
```bash
# Verify we can authenticate before trying operations
ldapwhoami -x -H ldap://$LDAP_SERVER -D "$ADMIN_DN" -w "$ADMIN_PASSWORD"
```

#### 4. Network Debugging on Failure
If connection fails after retries:
```bash
nslookup $LDAP_SERVER  # DNS resolution
nc -zv $LDAP_SERVER 389  # TCP connectivity
```

### 📦 Additional Dependencies
Added packages for debugging and connectivity testing:
- **ldap-utils**: LDAP client tools (`ldapadd`, `ldappasswd`, `ldapsearch`, `ldapwhoami`)
- **netcat-openbsd**: TCP connectivity testing (`nc` command)
- **dnsutils**: DNS debugging (`nslookup` command)

### ✅ Idempotency & Verification
**Check if user exists before creating:**
```bash
if ldapsearch -x -H ldap://$LDAP_SERVER -b "$USER_DN" "(objectClass=*)" | grep -q "^dn:"; then
  echo "✓ User already exists, skipping creation"
else
  ldapadd ...  # Create user
fi
```

**Verify each operation:**
- ✓ User creation
- ✓ Password set
- ✓ Account enabled
- ✓ Final verification with `ldapsearch`

---

## Technical Changes

### Files Modified: `modules/kube1/3_create_ad_user_job.tf`

#### Container Command (lines 205-217)
```diff
- apt-get update && apt-get install -y ldap-utils
- chmod +x /scripts/set-password.sh
- /scripts/set-password.sh
+ apt-get update -qq
+ apt-get install -y -qq ldap-utils netcat-openbsd dnsutils
+ cp /scripts/set-password.sh /tmp/set-password.sh
+ chmod +x /tmp/set-password.sh
+ /tmp/set-password.sh
```

#### Script Logic (lines 48-164)
- Added variables for readability
- Implemented 30-retry loop with 10s delay (5 min max)
- TCP connectivity check before LDAP operations
- LDAP authentication test (`ldapwhoami`)
- Idempotent user creation (check existence first)
- Individual verification steps for each operation
- Structured logging with ✓/✗ indicators
- Network debugging on failure

#### Timeout (lines 185-189)
```diff
- create = "5m"
+ create = "10m"  # Accommodate retry logic
```

---

## Sample Output

### ✅ Success Case
```
===============================================
AD User Creation Job Starting
LDAP Server: 10.0.48.99
User: vault-demo
User DN: CN=vault-demo,CN=Users,DC=mydomain,DC=local
===============================================
Waiting for LDAP server to be ready...
✓ LDAP server is reachable on port 389
Waiting 10 seconds for LDAP service to fully initialize...
Testing LDAP authentication...
✓ LDAP authentication successful
Checking if user vault-demo already exists...
Creating user vault-demo...
✓ User created successfully
Setting initial password...
✓ Password set successfully
Enabling the account...
✓ Account enabled successfully
Verifying user creation...
✓ User verification successful
===============================================
✓ AD User Creation Job Completed Successfully
User: vault-demo
DN: CN=vault-demo,CN=Users,DC=mydomain,DC=local
Initial password: VaultDemo123!
Note: This password will be rotated by Vault
===============================================
```

### ⏳ Retry Behavior (LDAP server slow to start)
```
Waiting for LDAP server to be ready...
Waiting for LDAP server... (attempt 1/30)
Waiting for LDAP server... (attempt 2/30)
Waiting for LDAP server... (attempt 3/30)
✓ LDAP server is reachable on port 389
[continues with user creation]
```

### ❌ Failure Case (LDAP server unreachable)
```
Waiting for LDAP server to be ready...
Waiting for LDAP server... (attempt 1/30)
...
Waiting for LDAP server... (attempt 30/30)
✗ ERROR: LDAP server not reachable after 30 attempts
Network debugging:
- Testing DNS resolution:
Server:    10.0.0.2
Address:   10.0.0.2#53
Name:      10.0.48.99
Address:   10.0.48.99
- Testing connectivity:
nc: connect to 10.0.48.99 port 389 (tcp) failed: Connection refused
```

---

## Execution Flow

```mermaid
graph TD
    A[Job Starts] --> B[Install Dependencies]
    B --> C[Copy Script to /tmp]
    C --> D[Make Executable]
    D --> E{TCP Port 389<br/>Reachable?}
    E -->|No| F[Wait 10s]
    F --> G{Retry < 30?}
    G -->|Yes| E
    G -->|No| H[Network Debug & Fail]
    E -->|Yes| I[Wait 10s for Init]
    I --> J{LDAP Auth<br/>Success?}
    J -->|No| K[Fail with Error]
    J -->|Yes| L{User Exists?}
    L -->|Yes| M[Skip Creation]
    L -->|No| N[Create User]
    M --> O[Set Password]
    N --> O
    O --> P[Enable Account]
    P --> Q[Verify User]
    Q --> R[✓ Success]
```

---

## Testing Recommendations

### After Deployment

1. **Monitor job execution:**
   ```bash
   kubectl get job create-ad-user -n simple-app
   kubectl logs job/create-ad-user -n simple-app -f
   ```

2. **Verify user was created:**
   ```bash
   # From Vault pod
   kubectl exec -it <vault-pod> -n simple-app -- \
     vault read ldap/static-cred/demo-service-account
   ```

3. **Test retry behavior:**
   - Delete and recreate the job while LDAP is starting
   - Should see retry attempts in logs

4. **Test idempotency:**
   - Run job multiple times
   - Should skip creation if user exists

---

## Breaking Changes
None - enhanced existing job with better error handling.

## Dependencies
- Requires LDAP component to be deployed first (already enforced)
- Works with PR #44 (job creation) and PR #42 (`skip_import_rotation = false`)

## Follow-up
After this PR merges and job successfully creates the user:
- Vault should be able to rotate the password
- VSO will sync real credentials to Kubernetes secret
- Python app will display password and DN values