### PR TITLE
Fix EKS module taints syntax - use map instead of list

### DIFF
--- a/modules/kube0/1_aws_eks.tf
+++ b/modules/kube0/1_aws_eks.tf
@@ -74,13 +74,13 @@ module "eks" {
         os       = "windows"
       }
 
-      taints = [
-        {
+      taints = {
+        windows = {
           key    = "os"
           value  = "windows"
           effect = "NoSchedule"
         }
-      ]
+      }
     }
   }
 }


### PR DESCRIPTION
Fixes #61

## Problem

Terraform plan failed with:

```
Error: The given value is not suitable for module.eks.var.eks_managed_node_groups 
declared at registry.terraform.io/terraform-aws-modules/eks/aws@21.11.0//variables.tf:1232,1-35: 
element "windows_nodes": attribute "taints": map of object required.
```

## Root Cause

The `terraform-aws-modules/eks/aws` module expects **taints as a map**, not a list.

## Solution

Simple syntax fix:

**Before (incorrect):**
```hcl
taints = [
  {
    key    = "os"
    value  = "windows"
    effect = "NoSchedule"
  }
]
```

**After (correct):**
```hcl
taints = {
  windows = {
    key    = "os"
    value  = "windows"
    effect = "NoSchedule"
  }
}
```

The map key (`windows`) is just a Terraform identifier - the actual Kubernetes taint applied is still `os=windows:NoSchedule`.

## Impact

- ✅ No functional change - same taint gets applied
- ✅ Only syntax fix - matches module's expected format
- ✅ `terraform validate` now passes
- ✅ Should allow `terraform plan` to proceed

## Testing

```bash
$ terraform fmt -recursive
$ terraform validate
Success! The configuration is valid.
```

Ready to merge! 🚀