### PR TITLE
Fix taint effect value - AWS requires NO_SCHEDULE not NoSchedule

### DIFF
--- a/modules/kube0/1_aws_eks.tf
+++ b/modules/kube0/1_aws_eks.tf
@@ -78,7 +78,7 @@ module "eks" {
         windows = {
           key    = "os"
           value  = "windows"
-          effect = "NoSchedule"
+          effect = "NO_SCHEDULE"
         }
       }
     }


### PR DESCRIPTION
Fixes #63

## Problem

Terraform apply failed with validation error:

```
Error: expected effect to be one of ["NO_SCHEDULE" "NO_EXECUTE" "PREFER_NO_SCHEDULE"], 
got NoSchedule
```

## Root Cause

**AWS quirk:** The AWS EKS Terraform provider uses different taint effect values than standard Kubernetes.

| Format | Values | Status |
|--------|--------|--------|
| **Kubernetes** | `NoSchedule`, `NoExecute`, `PreferNoSchedule` | ❌ Not accepted by AWS provider |
| **AWS Provider** | `NO_SCHEDULE`, `NO_EXECUTE`, `PREFER_NO_SCHEDULE` | ✅ Required |

AWS uses **UPPERCASE_WITH_UNDERSCORES** instead of **CamelCase**.

## Solution

One character change - literally just uppercase and underscore:

```diff
  taints = {
    windows = {
      key    = "os"
      value  = "windows"
-     effect = "NoSchedule"
+     effect = "NO_SCHEDULE"
    }
  }
```

## Important Note

Despite this format difference in Terraform:
- The **actual Kubernetes taint** on the nodes will be `os=windows:NoSchedule` (standard format)
- AWS automatically translates `NO_SCHEDULE` → `NoSchedule` when creating nodes
- Our pod tolerations using `NoSchedule` will work correctly

This is **only** a Terraform provider format requirement, not a functional difference.

## Verification

```bash
$ terraform validate
Success! The configuration is valid.
```

Should now pass `terraform plan` and `terraform apply` without validation errors.

## References

- [AWS EKS Node Group Taint Docs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_node_group#taint)
- [Kubernetes Taints Documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/)

Ready to merge! 🚀