### PR TITLE
Fix EBS CSI Driver - use before_compute instead of configuration_values

### DIFF
--- a/modules/kube0/1_aws_eks.tf
+++ b/modules/kube0/1_aws_eks.tf
@@ -43,20 +43,7 @@ module "eks" {
     }
     aws-ebs-csi-driver = {
       service_account_role_arn = aws_iam_role.ebs_csi_driver.arn
-      # Configure to run on Linux nodes only (not Windows nodes)
-      # Windows nodes cannot run the Linux-based EBS CSI Driver containers
-      configuration_values = jsonencode({
-        node = {
-          nodeSelector = {
-            "kubernetes.io/os" = "linux"
-          }
-        }
-        controller = {
-          nodeSelector = {
-            "kubernetes.io/os" = "linux"
-          }
-        }
-      })
+      before_compute           = true
     }
   }
 


### PR DESCRIPTION
Fixes #67 - Simple one-line fix using proven EKS pattern