### PR TITLE
Fix VPC CNI invalid schema - remove unsupported configuration

### DIFF
--- a/modules/kube0/1_aws_eks.tf
+++ b/modules/kube0/1_aws_eks.tf
@@ -40,13 +40,9 @@ module "eks" {
     }
     vpc-cni = {
       before_compute = true
-      # Enable Windows IPAM for Windows pod networking
-      # Required for Windows nodes to assign IP addresses to pods
-      configuration_values = jsonencode({
-        env = {
-          ENABLE_WINDOWS_IPAM = "true"
-        }
-      })
+      # Note: Windows IPAM configuration via add-on configuration_values is not supported
+      # Windows networking may auto-configure when Windows nodes join, or may require
+      # manual post-deployment configuration if pods fail to get IPs
     }
     aws-ebs-csi-driver = {
       service_account_role_arn = aws_iam_role.ebs_csi_driver.arn

--- a/modules/kube0/outputs.tf
+++ b/modules/kube0/outputs.tf
@@ -30,8 +30,8 @@ output "eks_cluster_name" {
 
 output "eks_cluster_id" {
   description = "The ID of the EKS cluster."
-  value       = module.eks.cluster_id 
-  sensitive   = false 
+  value       = module.eks.cluster_id
+  sensitive   = false
 }
 
 output "eks_cluster_auth" {

--- a/modules/kube0/variables.tf
+++ b/modules/kube0/variables.tf
@@ -1,17 +1,17 @@
 variable "user_email" {
-  type = string
+  type        = string
   description = "e-mail address"
-  default = "user@ibm.com"
+  default     = "user@ibm.com"
 }
 
 variable "instance_type" {
-  type = string
+  type        = string
   description = "EKS worker node instance type"
-  default = "t3.medium"
+  default     = "t3.medium"
 }
 
 variable "customer_name" {
-  type = string
+  type        = string
   description = "Customer name"
 }
 


### PR DESCRIPTION
Fixes #71

Remove invalid `configuration_values` from VPC CNI add-on. Windows networking may require manual enablement after deployment if pods fail to get IPs.