### PR TITLE
Add null provider to kube1 component

### DIFF
--- a/components.tfcomponent.hcl
+++ b/components.tfcomponent.hcl
@@ -34,6 +34,7 @@ component "kube1" {
     kubernetes = provider.kubernetes.this
     helm       = provider.helm.this
     time       = provider.time.this
+    null       = provider.null.this
   }
 
 }


### PR DESCRIPTION
Fixes #77

## Problem
The kube1 module uses `null_resource` in `1_enable_windows_ipam.tf` to enable Windows IPAM via kubectl, but the kube1 component configuration was missing the null provider.

## Solution
Added `null = provider.null.this` to the kube1 component's providers block.

## Changes
- `components.tfcomponent.hcl`: Added null provider to kube1 component

## Impact
- ✅ Terraform can now properly initialize the null provider for kube1
- ✅ Windows IPAM enablement will work correctly
- ✅ No other changes needed