### PR TITLE
Fix Windows IPAM Dependency Ordering

### DIFF
--- a/components.tfcomponent.hcl
+++ b/components.tfcomponent.hcl
@@ -26,14 +26,28 @@ component "kube1" {
     cluster_endpoint                        = component.kube0.cluster_endpoint
     kube_cluster_certificate_authority_data = component.kube0.kube_cluster_certificate_authority_data
     vault_license_key                       = var.vault_license_key
-    ldap_dc_private_ip                      = component.ldap.dc-priv-ip
-    ldap_admin_password                     = component.ldap.password
   }
   providers = {
     aws        = provider.aws.this
     kubernetes = provider.kubernetes.this
     helm       = provider.helm.this
     time       = provider.time.this
+  }
+
+}
+
+component "windows_config" {
+  source = "./modules/windows_config"
+  inputs = {
+    demo_id                                 = component.kube0.demo_id
+    cluster_endpoint                        = component.kube0.cluster_endpoint
+    kube_cluster_certificate_authority_data = component.kube0.kube_cluster_certificate_authority_data
+    kube_namespace                          = component.kube1.kube_namespace
+    ldap_dc_private_ip                      = component.ldap.dc-priv-ip
+    ldap_admin_password                     = component.ldap.password
+  }
+  providers = {
+    kubernetes = provider.kubernetes.this
   }
 
 }
@@ -122,7 +136,7 @@ component "vault_ldap_secrets" {
     kubernetes_ca_cert      = component.kube0.kube_cluster_certificate_authority_data
     kube_namespace          = component.kube1.kube_namespace
     # This dependency ensures the AD user creation job completes before Vault configures the LDAP secrets engine
-    ad_user_job_completed   = component.kube1.ad_user_job_status
+    ad_user_job_completed   = component.windows_config.ad_user_job_status
   }
   providers = {
     vault = provider.vault.this

--- a/modules/AWS_DC/variables.tf
+++ b/modules/AWS_DC/variables.tf
@@ -1,69 +1,69 @@
 variable "allowlist_ip" {
-  type = string
+  type        = string
   description = "IP to allow access for the security groups."
 }
 
 variable "prefix" {
-  type = string
+  type        = string
   description = "Prefix used to name various infrastructure components. Alphanumeric characters only."
   default     = "boundary-rdp"
 }
 
 variable "aws_key_pair_name" {
-  type = string
+  type        = string
   description = "key_name for the aws_key_pair resource"
-  default = "RDPKey"
+  default     = "RDPKey"
 }
 
 variable "ami" {
-  type = string
+  type        = string
   description = "The AMI to use for the windows instances."
-  default = "ami-08f787888f20cc63c"
+  default     = "ami-08f787888f20cc63c"
 }
 
 variable "domain_controller_instance_type" {
-  type = string
+  type        = string
   description = "The AWS instance type to use for servers."
   default     = "m7i-flex.xlarge"
 }
 
 variable "root_block_device_size" {
-  type = string
+  type        = string
   description = "The volume size of the root block device."
   default     = 128
 }
 
 variable "active_directory_domain" {
-  type = string 
+  type        = string
   description = "The name of the Active Directory domain to be created on the Windows Domain Controller."
-  default = "mydomain.local"
+  default     = "mydomain.local"
 }
 
 variable "active_directory_netbios_name" {
-  type = string
+  type        = string
   description = "Ostensibly the short-hand for the name of the domain."
-  default = "mydomain"
+  default     = "mydomain"
 }
 
 variable "only_ntlmv2" {
-  type = bool
+  type        = bool
   description = "Only use NTLMv2"
-  default = false
+  default     = false
 }
 
 variable "only_kerberos" {
-  type = bool
+  type        = bool
   description = "Only allow kerberos auth"
-  default = false
+  default     = false
 }
 
 variable "vpc_id" {
-  type = string
+  type        = string
   description = "The VPC ID where the LDAP server will be deployed."
 }
 
 variable "subnet_id" {
-  type = string
+  type        = string
   description = "The Subnet ID where the LDAP server will be deployed."
 }
 

--- a/modules/admin_vm/main.tf
+++ b/modules/admin_vm/main.tf
@@ -92,10 +92,10 @@ locals {
 }
 
 resource "aws_instance" "admin_vm" {
-  ami                    = data.aws_ami.amazon_linux_2023.id
-  instance_type          = var.instance_type
-  key_name               = var.key_name
-  subnet_id              = var.subnet_id
+  ami           = data.aws_ami.amazon_linux_2023.id
+  instance_type = var.instance_type
+  key_name      = var.key_name
+  subnet_id     = var.subnet_id
   vpc_security_group_ids = [
     aws_security_group.admin_vm_ssh.id,
     var.shared_internal_sg_id

--- a/modules/kube1/outputs.tf
+++ b/modules/kube1/outputs.tf
@@ -4,10 +4,3 @@ output "kube_namespace" {
   ephemeral   = false
   sensitive   = false
 }
-
-output "ad_user_job_status" {
-  description = "Status of the AD user creation job - used to ensure job completes before Vault LDAP secrets engine configuration"
-  value       = kubernetes_job_v1.create_ad_user.metadata[0].name
-  ephemeral   = false
-  sensitive   = false
-}

--- a/modules/kube1/variables.tf
+++ b/modules/kube1/variables.tf
@@ -18,14 +18,3 @@ variable "vault_license_key" {
   type        = string
   sensitive   = false
 }
-
-variable "ldap_dc_private_ip" {
-  description = "Private IP address of the Active Directory Domain Controller"
-  type        = string
-}
-
-variable "ldap_admin_password" {
-  description = "Administrator password for the Active Directory Domain Controller"
-  type        = string
-  sensitive   = true
-}  

--- a/modules/kube2/4_ldap_app.tf
+++ b/modules/kube2/4_ldap_app.tf
@@ -2,9 +2,9 @@
 # This deployment demonstrates LDAP static role credentials delivered via VSO
 
 locals {
-  ldap_app_name          = "ldap-credentials-app"
-  ldap_app_secret_name   = "ldap-credentials"
-  ldap_app_image         = "ghcr.io/andybaran/vault-ldap-demo:v1.1.0"
+  ldap_app_name        = "ldap-credentials-app"
+  ldap_app_secret_name = "ldap-credentials"
+  ldap_app_image       = "ghcr.io/andybaran/vault-ldap-demo:v1.1.0"
 }
 
 # VaultDynamicSecret CR for LDAP credentials

--- a/modules/vault/outputs.tf
+++ b/modules/vault/outputs.tf
@@ -68,5 +68,5 @@ output "vault_ui_loadbalancer_hostname" {
 
 output "vso_vault_auth_name" {
   description = "The name of the VaultAuth resource for VSO"
-  value       = "default"  # Matches the name defined in vso.tf VaultAuth resource
+  value       = "default" # Matches the name defined in vso.tf VaultAuth resource
 }

--- a/modules/vault/storage.tf
+++ b/modules/vault/storage.tf
@@ -5,7 +5,7 @@ resource "kubernetes_storage_class_v1" "vault_storage" {
   }
 
   storage_provisioner    = "ebs.csi.aws.com"
-  reclaim_policy        = "Delete"
+  reclaim_policy         = "Delete"
   allow_volume_expansion = true
   volume_binding_mode    = "WaitForFirstConsumer"
 

--- a/modules/vault/vault.tf
+++ b/modules/vault/vault.tf
@@ -5,143 +5,143 @@ resource "helm_release" "vault_cluster" {
   chart      = "vault"
   namespace  = var.kube_namespace
   version    = "0.31.0"
-#   values = [<<-EOT
-# global:
-# server:
-#   ha:
-#     enabled: true
-#   raft:
-#     enabled: true
-#   image:
-#     repository: hashicorp/vault-enterprise
-#     tag: 1.21.2-ent 
-#   enterpriseLicense:
-#     secretName: "vault-license"
-# ui:
-#   enabled: true
-# EOT
-# ]
-    set = [
-        { 
-            name = "global.tlsDisable"
-            value = "true"
-        },
+  #   values = [<<-EOT
+  # global:
+  # server:
+  #   ha:
+  #     enabled: true
+  #   raft:
+  #     enabled: true
+  #   image:
+  #     repository: hashicorp/vault-enterprise
+  #     tag: 1.21.2-ent 
+  #   enterpriseLicense:
+  #     secretName: "vault-license"
+  # ui:
+  #   enabled: true
+  # EOT
+  # ]
+  set = [
     {
-        name  = "server.ha.enabled"
-        value = "true"
+      name  = "global.tlsDisable"
+      value = "true"
     },
     {
-        name  = "server.ha.raft.enabled"
-        value = "true"
-    },
-        {
-        name  = "server.ha.raft.setNodeId"
-        value = "true"
+      name  = "server.ha.enabled"
+      value = "true"
     },
     {
-        name = "server.image.repository"
-        value = "hashicorp/vault-enterprise"
+      name  = "server.ha.raft.enabled"
+      value = "true"
     },
     {
-        name = "server.image.tag"
-        value = "1.21.2-ent"
+      name  = "server.ha.raft.setNodeId"
+      value = "true"
     },
     {
-        name  = "server.enterpriseLicense.secretName"
-        value = "vault-license"
-    },
-        {
-        name  = "server.enterpriseLicense.secretKey"
-        value = "license"
+      name  = "server.image.repository"
+      value = "hashicorp/vault-enterprise"
     },
     {
-        name  = "ui.enabled"
-        value = "true"
+      name  = "server.image.tag"
+      value = "1.21.2-ent"
     },
     {
-        name  = "server.dataStorage.enabled"
-        value = "true"
+      name  = "server.enterpriseLicense.secretName"
+      value = "vault-license"
     },
     {
-        name  = "server.dataStorage.size"
-        value = "10Gi"
+      name  = "server.enterpriseLicense.secretKey"
+      value = "license"
     },
     {
-        name  = "server.dataStorage.storageClass"
-        value = kubernetes_storage_class_v1.vault_storage.metadata[0].name
+      name  = "ui.enabled"
+      value = "true"
     },
     {
-        name  = "server.dataStorage.accessMode"
-        value = "ReadWriteOnce"
+      name  = "server.dataStorage.enabled"
+      value = "true"
     },
     {
-        name  = "server.auditStorage.enabled"
-        value = "true"
+      name  = "server.dataStorage.size"
+      value = "10Gi"
     },
     {
-        name  = "server.auditStorage.size"
-        value = "10Gi"
+      name  = "server.dataStorage.storageClass"
+      value = kubernetes_storage_class_v1.vault_storage.metadata[0].name
     },
     {
-        name  = "server.auditStorage.storageClass"
-        value = kubernetes_storage_class_v1.vault_storage.metadata[0].name
+      name  = "server.dataStorage.accessMode"
+      value = "ReadWriteOnce"
     },
     {
-        name  = "server.auditStorage.accessMode"
-        value = "ReadWriteOnce"
+      name  = "server.auditStorage.enabled"
+      value = "true"
     },
     {
-        name = "injector.enabled"
-        value = "false"
+      name  = "server.auditStorage.size"
+      value = "10Gi"
     },
     {
-        name = "ingress.enabled"
-        value = "true"
+      name  = "server.auditStorage.storageClass"
+      value = kubernetes_storage_class_v1.vault_storage.metadata[0].name
     },
     {
-        name = "csi.enabled"
-        value = "true"
+      name  = "server.auditStorage.accessMode"
+      value = "ReadWriteOnce"
     },
     {
-        name = "server.service.type"
-        value = "LoadBalancer"
+      name  = "injector.enabled"
+      value = "false"
     },
     {
-        name = "server.service.annotations.service\\.beta\\.kubernetes\\.io/aws-load-balancer-type"
-        value = "nlb"
+      name  = "ingress.enabled"
+      value = "true"
     },
     {
-        name = "server.service.annotations.service\\.beta\\.kubernetes\\.io/aws-load-balancer-scheme"
-        value = "internal"
+      name  = "csi.enabled"
+      value = "true"
     },
     {
-        name = "server.service.annotations.service\\.beta\\.kubernetes\\.io/aws-load-balancer-backend-protocol"
-        value = "tcp"
+      name  = "server.service.type"
+      value = "LoadBalancer"
     },
     {
-        name = "server.service.annotations.service\\.beta\\.kubernetes\\.io/aws-load-balancer-healthcheck-path"
-        value = "/v1/sys/health?standbyok=false&perfstandbyok=false"
+      name  = "server.service.annotations.service\\.beta\\.kubernetes\\.io/aws-load-balancer-type"
+      value = "nlb"
     },
     {
-        name = "server.service.annotations.service\\.beta\\.kubernetes\\.io/aws-load-balancer-healthcheck-protocol"
-        value = "http"
+      name  = "server.service.annotations.service\\.beta\\.kubernetes\\.io/aws-load-balancer-scheme"
+      value = "internal"
     },
     {
-        name  = "server.service.annotations.service\\.beta\\.kubernetes\\.io/aws-load-balancer-healthcheck-port"
-        value = "traffic-port"
+      name  = "server.service.annotations.service\\.beta\\.kubernetes\\.io/aws-load-balancer-backend-protocol"
+      value = "tcp"
     },
     {
-        name = "ui.serviceType"
-        value = "LoadBalancer"
+      name  = "server.service.annotations.service\\.beta\\.kubernetes\\.io/aws-load-balancer-healthcheck-path"
+      value = "/v1/sys/health?standbyok=false&perfstandbyok=false"
     },
     {
-        name = "ui.annotations.service\\.beta\\.kubernetes\\.io/aws-load-balancer-type"
-        value = "nlb"
+      name  = "server.service.annotations.service\\.beta\\.kubernetes\\.io/aws-load-balancer-healthcheck-protocol"
+      value = "http"
     },
     {
-        name = "ui.annotations.service\\.beta\\.kubernetes\\.io/aws-load-balancer-scheme"
-        value = "internal"
+      name  = "server.service.annotations.service\\.beta\\.kubernetes\\.io/aws-load-balancer-healthcheck-port"
+      value = "traffic-port"
+    },
+    {
+      name  = "ui.serviceType"
+      value = "LoadBalancer"
+    },
+    {
+      name  = "ui.annotations.service\\.beta\\.kubernetes\\.io/aws-load-balancer-type"
+      value = "nlb"
+    },
+    {
+      name  = "ui.annotations.service\\.beta\\.kubernetes\\.io/aws-load-balancer-scheme"
+      value = "internal"
     }
 
-    ]
+  ]
 }

--- a/modules/vault/vso.tf
+++ b/modules/vault/vso.tf
@@ -69,7 +69,7 @@ resource "kubernetes_manifest" "vault_auth" {
       namespace = var.kube_namespace
     }
     spec = {
-      vaultConnectionRef = "default"  # References VaultConnection name
+      vaultConnectionRef = "default" # References VaultConnection name
       method             = "kubernetes"
       mount              = "kubernetes"
       kubernetes = {

--- a/modules/vault_ldap_secrets/kubernetes_auth.tf
+++ b/modules/vault_ldap_secrets/kubernetes_auth.tf
@@ -12,7 +12,7 @@ resource "vault_kubernetes_auth_backend_config" "config" {
   backend            = vault_auth_backend.kubernetes.path
   kubernetes_host    = var.kubernetes_host
   kubernetes_ca_cert = base64decode(var.kubernetes_ca_cert)
-  
+
   # When disable_local_ca_jwt is false, Vault validates JWT tokens locally using the CA cert
   # This is more reliable than calling the K8s API for token review
   disable_local_ca_jwt = false

--- a/modules/windows_config/outputs.tf
+++ b/modules/windows_config/outputs.tf
@@ -1,0 +1,17 @@
+# Outputs for windows_config module
+
+output "windows_ipam_enabled" {
+  description = "Status of Windows IPAM enablement job"
+  value       = kubernetes_job_v1.windows_k8s_config.metadata[0].name
+}
+
+output "ad_user_job_status" {
+  description = "Status of AD user creation job (for vault_ldap_secrets dependency)"
+  value       = kubernetes_job_v1.create_ad_user.metadata[0].name
+}
+
+output "vault_demo_initial_password" {
+  description = "Initial password for vault-demo user (will be rotated by Vault)"
+  value       = local.vault_demo_initial_password
+  sensitive   = true
+}

--- a/modules/windows_config/variables.tf
+++ b/modules/windows_config/variables.tf
@@ -1,0 +1,32 @@
+# Variables for windows_config module
+
+variable "demo_id" {
+  description = "Unique identifier for this demo instance"
+  type        = string
+}
+
+variable "cluster_endpoint" {
+  description = "EKS cluster endpoint"
+  type        = string
+}
+
+variable "kube_cluster_certificate_authority_data" {
+  description = "EKS cluster certificate authority data"
+  type        = string
+}
+
+variable "kube_namespace" {
+  description = "Kubernetes namespace for resources"
+  type        = string
+}
+
+variable "ldap_dc_private_ip" {
+  description = "Private IP address of the LDAP/AD domain controller"
+  type        = string
+}
+
+variable "ldap_admin_password" {
+  description = "LDAP administrator password"
+  type        = string
+  sensitive   = true
+}


### PR DESCRIPTION
## Summary
This PR fixes a critical dependency ordering issue where the AD user creation job was attempting to run before Windows IPAM was enabled, causing failures.

## Problem
The current implementation had a race condition:
1. **kube1** component ran before **vault_cluster** component
2. The `create-ad-user` job (in kube1) needed `ENABLE_WINDOWS_IPAM=true` to run Windows pods
3. But Windows IPAM enablement was in the `vault_init` job (in vault_cluster)
4. Result: create-ad-user job **failed** because Windows IPAM wasn't enabled yet

## Solution
Created a new **windows_config** component that:
- Runs after kube1 (has namespace)
- Enables Windows IPAM first (Job 1)
- Then creates the AD user (Job 2, depends on Job 1)
- Vault LDAP secrets engine waits for this to complete

## Dependency Chain
```
kube0 (EKS cluster)
  ↓
kube1 (namespace creation)
  ↓
windows_config (Windows IPAM + AD user) ← NEW
  ↓
vault_cluster (Vault init - no longer sets Windows IPAM)
  ↓
vault_ldap_secrets (LDAP secrets engine)
  ↓
kube2 (LDAP app)
```

## Changes Made
- ✅ Created new `modules/windows_config/` module
  - Windows IPAM enablement job
  - AD user creation job (moved from kube1)
  - RBAC resources (ClusterRole/ClusterRoleBinding)
- ✅ Updated `components.tfcomponent.hcl`
  - Added windows_config component
  - Updated vault_ldap_secrets dependency
- ✅ Updated `modules/vault/vault_init.tf`
  - Removed Windows IPAM logic
  - Removed VPC CNI RBAC resources
- ✅ Updated `modules/kube1/`
  - Removed AD user creation job
  - Removed LDAP-related variables and outputs

## Testing
- [ ] Terraform plan shows expected changes
- [ ] Stack deployment succeeds with correct ordering
- [ ] Windows IPAM is enabled before AD user creation
- [ ] AD user is created successfully
- [ ] Vault LDAP secrets engine configures correctly

Fixes #81