### PR TITLE
Fix EKS Module Unsupported Argument Error

### DIFF
--- a/modules/kube0/1_aws_eks.tf
+++ b/modules/kube0/1_aws_eks.tf
@@ -26,7 +26,6 @@ module "eks" {
 
   # Additional IAM policies for cluster role
   # AmazonEKSVPCResourceController is required for Windows support
-  cluster_additional_security_group_ids = []
   iam_role_additional_policies = {
     AmazonEKSVPCResourceController = "arn:aws:iam::aws:policy/AmazonEKSVPCResourceController"
   }


### PR DESCRIPTION
## Problem
Terraform fails with an unsupported argument error:

```
Error: Unsupported argument
Error: An argument named "cluster_additional_security_group_ids" is not expected here.
on modules/kube0/1_aws_eks.tf line 29, in 'module "eks"':
29: cluster_additional_security_group_ids = []
```

## Root Cause
The argument `cluster_additional_security_group_ids` does not exist in the terraform-aws-modules/eks/aws module version 21.11.0.

This was accidentally added in PR #86 alongside the correct `iam_role_additional_policies` argument when adding Windows support IAM policy.

## Research
The correct arguments in the EKS module v21.11.0 are:
- ✅ `iam_role_additional_policies` - Map of additional IAM policies to attach to cluster role (CORRECT - kept)
- ❌ `cluster_additional_security_group_ids` - Does NOT exist (REMOVED)
- Note: `cluster_security_group_additional_rules` exists for security group rules, but that's different

## Solution
Removed the invalid `cluster_additional_security_group_ids = []` line.

The correct `iam_role_additional_policies` argument remains in place to attach the AmazonEKSVPCResourceController IAM policy (required for Windows support).

## Changes
- ❌ Removed: `cluster_additional_security_group_ids = []`
- ✅ Kept: `iam_role_additional_policies` with AmazonEKSVPCResourceController policy

## Files Modified
- `modules/kube0/1_aws_eks.tf` - Removed invalid argument

## Result
The EKS module configuration is now valid and will successfully attach the required Windows support IAM policy to the cluster role without errors.

Fixes #87