### PR TITLE
Fix Windows IPAM: use ConfigMap method and wait for Windows nodes

### DIFF
--- a/modules/windows_config/main.tf
+++ b/modules/windows_config/main.tf
@@ -11,17 +11,32 @@ resource "kubernetes_service_account_v1" "windows_config" {
   }
 }
 
-# ClusterRole with permissions to manage VPC CNI DaemonSet in kube-system
+# ClusterRole with permissions to manage VPC CNI and monitor Windows nodes
 resource "kubernetes_cluster_role_v1" "vpc_cni_manager" {
   metadata {
     name = "${var.kube_namespace}-vpc-cni-manager"
   }
 
+  # Manage VPC CNI DaemonSet
   rule {
     api_groups     = ["apps"]
     resources      = ["daemonsets"]
     resource_names = ["aws-node"]
     verbs          = ["get", "list", "patch", "update"]
+  }
+
+  # Read nodes to check Windows node readiness
+  rule {
+    api_groups = [""]
+    resources  = ["nodes"]
+    verbs      = ["get", "list"]
+  }
+
+  # Manage amazon-vpc-cni ConfigMap for Windows IPAM enablement
+  rule {
+    api_groups = [""]
+    resources  = ["configmaps"]
+    verbs      = ["get", "create", "update", "patch"]
   }
 }
 
@@ -44,8 +59,8 @@ resource "kubernetes_cluster_role_binding_v1" "vpc_cni_manager" {
   }
 }
 
-# Job 1: Enable Windows IPAM in VPC CNI
-# This MUST run first, before any Windows pods can be scheduled
+# Job 1: Enable Windows IPAM in VPC CNI and wait for Windows nodes
+# This MUST complete before any Windows pods can be scheduled
 resource "kubernetes_job_v1" "windows_k8s_config" {
   metadata {
     name      = "windows-k8s-config"
@@ -55,8 +70,8 @@ resource "kubernetes_job_v1" "windows_k8s_config" {
   wait_for_completion = true
 
   timeouts {
-    create = "15m"
-    update = "15m"
+    create = "20m"
+    update = "20m"
   }
 
   spec {
@@ -80,118 +95,136 @@ resource "kubernetes_job_v1" "windows_k8s_config" {
           args = [<<-EOT
             # Get kubectl
             echo "Downloading kubectl..."
-            wget https://dl.k8s.io/release/v1.35.0/bin/linux/amd64/kubectl
+            wget -q https://dl.k8s.io/release/v1.35.0/bin/linux/amd64/kubectl
             chmod +x kubectl
 
-            # Enable Windows IPAM for VPC CNI (required for Windows pods)
+            # ================================================
+            # Step 1: Enable Windows IPAM via ConfigMap
+            # Per AWS docs: https://docs.aws.amazon.com/eks/latest/userguide/windows-support.html
+            # ================================================
             echo "================================================"
-            echo "Enabling Windows IPAM in VPC CNI"
+            echo "Step 1: Enabling Windows IPAM via ConfigMap"
             echo "================================================"
-            
-            # Wait for aws-node DaemonSet to exist
-            echo "Waiting for VPC CNI aws-node DaemonSet..."
-            for i in $(seq 1 30); do
-              if ./kubectl get daemonset aws-node -n kube-system >/dev/null 2>&1; then
-                echo "✓ aws-node DaemonSet found"
-                break
-              fi
-              if [ $i -eq 30 ]; then
-                echo "✗ ERROR: Timeout waiting for aws-node DaemonSet"
-                exit 1
-              fi
-              echo "  Waiting... (attempt $i/30)"
-              sleep 10
-            done
 
-            # Check if Windows IPAM is already enabled
-            echo "Checking current Windows IPAM status..."
-            CURRENT_VALUE=$(./kubectl get daemonset aws-node -n kube-system -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="ENABLE_WINDOWS_IPAM")].value}' 2>/dev/null || echo "")
-            
+            # Check if ConfigMap already exists with correct value
+            CURRENT_VALUE=$(./kubectl get configmap amazon-vpc-cni -n kube-system -o jsonpath='{.data.enable-windows-ipam}' 2>/dev/null || echo "")
+
             if [ "$CURRENT_VALUE" = "true" ]; then
-              echo "✓ Windows IPAM already enabled"
+              echo "✓ Windows IPAM already enabled in ConfigMap"
             else
-              echo "Enabling Windows IPAM..."
-              ./kubectl set env daemonset/aws-node -n kube-system ENABLE_WINDOWS_IPAM=true
-              
-              # Verify the change
-              echo "Verifying Windows IPAM is enabled..."
-              UPDATED_VALUE=$(./kubectl get daemonset aws-node -n kube-system -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="ENABLE_WINDOWS_IPAM")].value}')
+              echo "Creating/updating amazon-vpc-cni ConfigMap..."
+              cat <<'CMEOF' | ./kubectl apply -f -
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: amazon-vpc-cni
+  namespace: kube-system
+data:
+  enable-windows-ipam: "true"
+CMEOF
+
+              # Verify ConfigMap was applied
+              UPDATED_VALUE=$(./kubectl get configmap amazon-vpc-cni -n kube-system -o jsonpath='{.data.enable-windows-ipam}')
               if [ "$UPDATED_VALUE" = "true" ]; then
-                echo "✓ Windows IPAM enabled successfully"
+                echo "✓ Windows IPAM enabled via ConfigMap"
               else
-                echo "✗ ERROR: Failed to verify Windows IPAM setting"
+                echo "✗ ERROR: Failed to enable Windows IPAM in ConfigMap"
                 exit 1
               fi
             fi
 
-            # Wait for DaemonSet rollout to complete
+            # Also set DaemonSet env as a belt-and-suspenders approach
+            echo "Setting ENABLE_WINDOWS_IPAM on DaemonSet as well..."
+            ./kubectl set env daemonset/aws-node -n kube-system ENABLE_WINDOWS_IPAM=true 2>/dev/null || true
+
+            # ================================================
+            # Step 2: Wait for VPC CNI DaemonSet rollout
+            # ================================================
             echo "================================================"
-            echo "Waiting for VPC CNI DaemonSet rollout..."
+            echo "Step 2: Waiting for VPC CNI DaemonSet rollout..."
             echo "================================================"
-            
+
             for i in $(seq 1 30); do
-              # Check DaemonSet rollout status
               DESIRED=$(./kubectl get daemonset aws-node -n kube-system -o jsonpath='{.status.desiredNumberScheduled}')
-              UPDATED=$(./kubectl get daemonset aws-node -n kube-system -o jsonpath='{.status.updatedNumberScheduled}')
+              UPDATED=$(./kubectl get daemonset aws-node -n kube-system -o jsonpath='{.status.updatedNumberScheduled}' 2>/dev/null || echo "0")
               AVAILABLE=$(./kubectl get daemonset aws-node -n kube-system -o jsonpath='{.status.numberAvailable}')
-              
-              echo "DaemonSet status: Desired=$DESIRED, Updated=$UPDATED, Available=$AVAILABLE"
-              
+
+              echo "  DaemonSet: Desired=$DESIRED Updated=$UPDATED Available=$AVAILABLE"
+
               if [ "$DESIRED" = "$UPDATED" ] && [ "$DESIRED" = "$AVAILABLE" ] && [ -n "$DESIRED" ] && [ "$DESIRED" != "0" ]; then
                 echo "✓ VPC CNI DaemonSet rollout complete"
                 break
               fi
-              
+
               if [ $i -eq 30 ]; then
-                echo "⚠ WARNING: DaemonSet rollout did not complete in time"
-                echo "Proceeding anyway - Windows nodes may need additional time"
+                echo "⚠ WARNING: DaemonSet rollout timed out, proceeding anyway"
               fi
-              
-              echo "  Waiting for rollout... (attempt $i/30)"
+
               sleep 10
             done
 
-            # Additional wait for Windows nodes to initialize with new IPAM config
-            # Windows networking initialization takes longer than Linux
+            # ================================================
+            # Step 3: Wait for Windows nodes to join and be Ready
+            # Windows managed node groups may take several minutes to launch
+            # ================================================
             echo "================================================"
-            echo "Waiting for Windows nodes to initialize..."
+            echo "Step 3: Waiting for Windows nodes to join cluster..."
             echo "================================================"
-            
-            # Check if Windows nodes exist
-            WINDOWS_NODE_COUNT=$(./kubectl get nodes -l kubernetes.io/os=windows --no-headers 2>/dev/null | wc -l)
-            echo "Found $WINDOWS_NODE_COUNT Windows node(s)"
-            
-            if [ "$WINDOWS_NODE_COUNT" -gt 0 ]; then
-              # Wait for Windows nodes to be Ready
-              echo "Checking Windows node readiness..."
-              for i in $(seq 1 30); do
-                READY_COUNT=$(./kubectl get nodes -l kubernetes.io/os=windows -o jsonpath='{range .items[*]}{.status.conditions[?(@.type=="Ready")].status}{"\n"}{end}' | grep -c "True" || echo "0")
-                echo "  Windows nodes ready: $READY_COUNT/$WINDOWS_NODE_COUNT"
-                
-                if [ "$READY_COUNT" = "$WINDOWS_NODE_COUNT" ]; then
-                  echo "✓ All Windows nodes are Ready"
-                  break
-                fi
-                
-                if [ $i -eq 30 ]; then
-                  echo "⚠ WARNING: Not all Windows nodes ready"
-                fi
-                
-                sleep 10
-              done
-              
-              # Give Windows IPAM additional time to fully initialize
-              # Windows CNI configuration is slower than Linux
-              echo "Allowing additional time for Windows IPAM initialization..."
-              sleep 30
-              
-              echo "✓ Windows nodes initialization wait completed"
-            else
-              echo "⚠ No Windows nodes found - skipping readiness check"
-              echo "Windows pods may fail if nodes are not yet joined to the cluster"
-            fi
 
-            echo "✓ Windows IPAM configuration completed"
+            for i in $(seq 1 60); do
+              WINDOWS_NODE_COUNT=$(./kubectl get nodes -l kubernetes.io/os=windows --no-headers 2>/dev/null | wc -l | tr -d ' ')
+
+              if [ "$WINDOWS_NODE_COUNT" -gt 0 ]; then
+                echo "✓ Found $WINDOWS_NODE_COUNT Windows node(s)"
+                break
+              fi
+
+              if [ $i -eq 60 ]; then
+                echo "✗ ERROR: No Windows nodes found after 10 minutes"
+                echo "Dumping all nodes for debugging:"
+                ./kubectl get nodes -o wide --show-labels
+                exit 1
+              fi
+
+              echo "  Waiting for Windows nodes to join... (attempt $i/60)"
+              sleep 10
+            done
+
+            # Wait for Windows nodes to be Ready
+            echo "Checking Windows node readiness..."
+            WINDOWS_NODE_COUNT=$(./kubectl get nodes -l kubernetes.io/os=windows --no-headers 2>/dev/null | wc -l | tr -d ' ')
+
+            for i in $(seq 1 60); do
+              READY_COUNT=$(./kubectl get nodes -l kubernetes.io/os=windows -o jsonpath='{range .items[*]}{.status.conditions[?(@.type=="Ready")].status}{"\n"}{end}' 2>/dev/null | grep -c "True" || echo "0")
+              echo "  Windows nodes Ready: $READY_COUNT/$WINDOWS_NODE_COUNT"
+
+              if [ "$READY_COUNT" -ge 1 ]; then
+                echo "✓ At least one Windows node is Ready"
+                break
+              fi
+
+              if [ $i -eq 60 ]; then
+                echo "✗ ERROR: No Windows nodes became Ready after 10 minutes"
+                echo "Dumping node status for debugging:"
+                ./kubectl describe nodes -l kubernetes.io/os=windows
+                exit 1
+              fi
+
+              sleep 10
+            done
+
+            # ================================================
+            # Step 4: Wait for Windows networking to be fully initialized
+            # The vpc-resource-controller needs time to allocate IPs
+            # ================================================
+            echo "================================================"
+            echo "Step 4: Verifying Windows networking readiness..."
+            echo "================================================"
+
+            echo "Waiting 60 seconds for vpc-resource-controller to allocate IPs to Windows nodes..."
+            sleep 60
+
+            echo "✓ Windows IPAM configuration and node readiness verified"
             echo "================================================"
           EOT
           ]


### PR DESCRIPTION
## Problem
The `create-ad-user` Windows job continues to fail with:
```
pod create-ad-user-qkfl7 does not have label vpc.amazonaws.com/PrivateIPv4Address
```

The `windows-k8s-config` job logs revealed the root cause:
```
Found 0 Windows node(s)
⚠ No Windows nodes found - skipping readiness check
```

The job was completing successfully but **Windows nodes hadn't joined yet**, so the subsequent create-ad-user pod had no functioning Windows networking.

## Root Causes & Fixes

### 1. ❌ Wrong IPAM enablement method → ✅ ConfigMap approach
**Before:** `kubectl set env daemonset/aws-node ENABLE_WINDOWS_IPAM=true`
**After:** Creates `amazon-vpc-cni` ConfigMap in `kube-system` with `enable-windows-ipam: "true"`

Per [AWS documentation](https://docs.aws.amazon.com/eks/latest/userguide/windows-support.html#enable-windows-support), the correct method is:
```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: amazon-vpc-cni
  namespace: kube-system
data:
  enable-windows-ipam: "true"
```
Also sets the DaemonSet env var as a belt-and-suspenders approach.

### 2. ❌ Job didn't wait for Windows nodes → ✅ Mandatory wait loop
**Before:** Found 0 nodes, printed a warning, and exited successfully
**After:** Waits up to 10 minutes for Windows nodes to join, then up to 10 more minutes for them to become Ready. **Fails with error** if nodes don't appear.

### 3. ❌ Missing RBAC permissions → ✅ Added node and ConfigMap access
**Before:** ClusterRole only allowed DaemonSet management
**After:** Added:
- `nodes` - `get`, `list` (check Windows node readiness)
- `configmaps` - `get`, `create`, `update`, `patch` (manage amazon-vpc-cni ConfigMap)

## Job Flow (4 Steps)
```
Step 1: Enable Windows IPAM via ConfigMap (+ DaemonSet env)
Step 2: Wait for VPC CNI DaemonSet rollout (up to 5 min)
Step 3: Wait for Windows nodes to join AND be Ready (up to 10 min each)
         ↳
Step 4: 60-second buffer for vpc-resource-controller IP allocation
```

## Changes
- `modules/windows_config/main.tf`:
  - Rewrote windows_k8s_config job script with 4-step approach
  - Added node and ConfigMap RBAC rules to ClusterRole
  - Increased job timeout from 15m to 20m

## Testing Checklist
- [ ] windows-k8s-config job creates amazon-vpc-cni ConfigMap
- [ ] Job waits until Windows nodes join the cluster
- [ ] Job waits until at least one Windows node is Ready
- [ ] create-ad-user pod receives vpc.amazonaws.com/PrivateIPv4Address label
- [ ] create-ad-user job completes successfully

Fixes #89