### PR TITLE
fix: simplify shared_internal SG to allow all VPC CIDR traffic (#91)

### DIFF
--- a/modules/kube0/2_security_groups.tf
+++ b/modules/kube0/2_security_groups.tf
@@ -1,14 +1,15 @@
 resource "aws_security_group" "shared_internal" {
   name        = "${local.resources_prefix}-shared-internal"
-  description = "Shared security group for internal communication between admin VM and domain controller"
+  description = "Shared security group for internal VPC communication (demo - allows all VPC traffic)"
   vpc_id      = module.vpc.vpc_id
 
+  # Allow all traffic from within the VPC (EKS pods, nodes, admin VM, DC)
   ingress {
-    description = "All traffic from members of this security group"
+    description = "All traffic from VPC CIDR"
     from_port   = 0
     to_port     = 0
     protocol    = "-1"
-    self        = true
+    cidr_blocks = [local.vpc_cidr]
   }
 
   egress {
@@ -22,69 +23,4 @@ resource "aws_security_group" "shared_internal" {
   tags = {
     Name = "${local.resources_prefix}-shared-internal"
   }
-}
-
-# Security group rule to allow LDAP traffic from EKS cluster to LDAP server
-# This enables the create-ad-user job running in EKS to connect to the DC
-resource "aws_security_group_rule" "ldap_from_eks" {
-  description              = "Allow LDAP traffic from EKS cluster nodes"
-  type                     = "ingress"
-  from_port                = 389
-  to_port                  = 389
-  protocol                 = "tcp"
-  source_security_group_id = module.eks.node_security_group_id
-  security_group_id        = aws_security_group.shared_internal.id
-}
-
-# Allow LDAPS (secure LDAP) as well in case it's needed
-resource "aws_security_group_rule" "ldaps_from_eks" {
-  description              = "Allow LDAPS traffic from EKS cluster nodes"
-  type                     = "ingress"
-  from_port                = 636
-  to_port                  = 636
-  protocol                 = "tcp"
-  source_security_group_id = module.eks.node_security_group_id
-  security_group_id        = aws_security_group.shared_internal.id
-}
-
-# Allow Kerberos from EKS (may be needed for AD authentication)
-resource "aws_security_group_rule" "kerberos_tcp_from_eks" {
-  description              = "Allow Kerberos TCP traffic from EKS cluster nodes"
-  type                     = "ingress"
-  from_port                = 88
-  to_port                  = 88
-  protocol                 = "tcp"
-  source_security_group_id = module.eks.node_security_group_id
-  security_group_id        = aws_security_group.shared_internal.id
-}
-
-resource "aws_security_group_rule" "kerberos_udp_from_eks" {
-  description              = "Allow Kerberos UDP traffic from EKS cluster nodes"
-  type                     = "ingress"
-  from_port                = 88
-  to_port                  = 88
-  protocol                 = "udp"
-  source_security_group_id = module.eks.node_security_group_id
-  security_group_id        = aws_security_group.shared_internal.id
-}
-
-# Allow DNS from EKS to DC (AD DNS)
-resource "aws_security_group_rule" "dns_tcp_from_eks" {
-  description              = "Allow DNS TCP traffic from EKS cluster nodes"
-  type                     = "ingress"
-  from_port                = 53
-  to_port                  = 53
-  protocol                 = "tcp"
-  source_security_group_id = module.eks.node_security_group_id
-  security_group_id        = aws_security_group.shared_internal.id
-}
-
-resource "aws_security_group_rule" "dns_udp_from_eks" {
-  description              = "Allow DNS UDP traffic from EKS cluster nodes"
-  type                     = "ingress"
-  from_port                = 53
-  to_port                  = 53
-  protocol                 = "udp"
-  source_security_group_id = module.eks.node_security_group_id
-  security_group_id        = aws_security_group.shared_internal.id
 }


### PR DESCRIPTION
## Summary

Fixes #91 — the create-ad-user Windows pod (IP 10.0.28.61) cannot connect to the domain controller.

## Root Cause

The `shared_internal` security group had individual ingress rules (LDAP/389, LDAPS/636, Kerberos/88, DNS/53) that used `source_security_group_id = module.eks.node_security_group_id`. Windows pods with VPC CNI secondary IPs may not match the node security group source filter, blocking connectivity to the DC.

## Changes

Replaced 6 per-port `aws_security_group_rule` resources with a single inline ingress rule allowing **all traffic from the VPC CIDR** (`10.0.0.0/16`). This ensures all resources in the VPC (EKS pods, nodes, admin VM, DC) can communicate freely — appropriate for this demo project.

**Before:** 1 security group + 6 separate security group rules (91 lines)
**After:** 1 security group with inline VPC CIDR rule (26 lines)