### PR TITLE
fix: use pre-built AD tools image and admin password for vault-demo user (#93)

### DIFF
--- a/.github/workflows/build-ad-tools-image.yml
+++ b/.github/workflows/build-ad-tools-image.yml
@@ -1,0 +1,38 @@
+name: Build AD Tools Windows Image
+
+on:
+  push:
+    paths:
+      - 'docker/ad-tools/**'
+    branches: [main]
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}/ad-tools
+
+jobs:
+  build-and-push:
+    runs-on: windows-2022
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image
+        run: |
+          $imageName = "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}".ToLower()
+          docker build -t "${imageName}:ltsc2022" -t "${imageName}:latest" docker/ad-tools/
+          docker push "${imageName}:ltsc2022"
+          docker push "${imageName}:latest"
+        shell: pwsh

--- a/docker/ad-tools/Dockerfile
+++ b/docker/ad-tools/Dockerfile
@@ -1,0 +1,10 @@
+# Windows Server Core image with RSAT-AD-PowerShell pre-installed
+# Used by the create-ad-user Kubernetes job to create AD users via PowerShell cmdlets
+FROM mcr.microsoft.com/windows/servercore:ltsc2022
+
+# Install RSAT Active Directory PowerShell module at build time
+# This avoids the 15-30 minute Install-WindowsFeature delay at runtime
+RUN powershell -Command "Install-WindowsFeature -Name RSAT-AD-PowerShell -ErrorAction Stop"
+
+# Verify the module is available
+RUN powershell -Command "Import-Module ActiveDirectory -ErrorAction Stop; Get-Command New-ADUser"


### PR DESCRIPTION
## Summary

Fixes #93 — the create-ad-user job times out because `Install-WindowsFeature -Name RSAT-AD-PowerShell` takes 15-30 minutes at runtime, exceeding the 10m Terraform timeout.

## Changes

### 1. Custom Windows container image
- **`docker/ad-tools/Dockerfile`** — Windows Server Core ltsc2022 with RSAT-AD-PowerShell pre-installed at build time
- **`.github/workflows/build-ad-tools-image.yml`** — GitHub Actions workflow (runs on `windows-2022` runner) to build and push to `ghcr.io/andybaran/aws-vault-ldap-k8s/ad-tools:ltsc2022` (public)
- Eliminates the 15-30 minute `Install-WindowsFeature` delay from every job run

### 2. Password fix
- Guarantees AD password complexity compliance
- Vault rotates it immediately after LDAP secrets engine configuration

### 3. Runtime improvements
- Container command changed from `pwsh` to `powershell -ExecutionPolicy Bypass` (servercore ships with Windows PowerShell, not PowerShell Core)
- Job timeout increased from 10m to 20m as safety margin

## ⚠️ Pre-merge requirement
The container image must be built and pushed to ghcr.io before this PR is merged. After merge, trigger the GitHub Actions workflow manually via `workflow_dispatch`, or it will auto-run on the next push to main that touches `docker/ad-tools/`.