### PR TITLE
fix: pass dynamic values via env vars to fix PowerShell parse errors (#95)

### DIFF
--- a/modules/windows_config/main.tf
+++ b/modules/windows_config/main.tf
@@ -247,7 +247,7 @@ locals {
   ad_tools_image              = "ghcr.io/andybaran/aws-vault-ldap-k8s/ad-tools:ltsc2022"
 }
 
-# Secret containing LDAP admin credentials for user creation
+# Secret containing credentials and config for AD user creation
 resource "kubernetes_secret_v1" "ldap_admin_creds" {
   metadata {
     name      = "ldap-admin-creds"
@@ -255,14 +255,19 @@ resource "kubernetes_secret_v1" "ldap_admin_creds" {
   }
 
   data = {
-    admin_dn       = local.ldap_admin_dn
-    admin_password = var.ldap_admin_password
+    admin_dn         = local.ldap_admin_dn
+    admin_password   = var.ldap_admin_password
+    ad_server        = local.ldap_server
+    vault_user       = local.vault_demo_username
+    initial_password = local.vault_demo_initial_password
   }
 
   type = "Opaque"
 }
 
 # ConfigMap with PowerShell script for creating the vault-demo user in Active Directory
+# NOTE: This script uses NO Terraform interpolation — all dynamic values come via env vars.
+# This prevents special characters in passwords from corrupting PowerShell syntax.
 resource "kubernetes_config_map_v1" "create_ad_user_script" {
   metadata {
     name      = "create-ad-user-script"
@@ -270,19 +275,20 @@ resource "kubernetes_config_map_v1" "create_ad_user_script" {
   }
 
   data = {
-    "Create-ADUser.ps1" = <<-EOT
+    "Create-ADUser.ps1" = <<-'EOT'
       # PowerShell script to create vault-demo user in Active Directory
-      # Uses native AD cmdlets from pre-installed RSAT-AD-PowerShell
-      
+      # All dynamic values are passed via environment variables to avoid
+      # Terraform interpolation issues with special characters in passwords.
+
       $ErrorActionPreference = "Stop"
-      
-      $ADServer = "${local.ldap_server}"
-      $VaultUser = "${local.vault_demo_username}"
-      $InitialPassword = "${local.vault_demo_initial_password}"
+
+      $ADServer = $env:AD_SERVER
+      $VaultUser = $env:VAULT_USER
+      $InitialPassword = $env:INITIAL_PASSWORD
       $UserDN = "CN=$VaultUser,CN=Users,DC=mydomain,DC=local"
       $MaxRetries = 30
       $RetryDelay = 10
-      
+
       Write-Host "==============================================="
       Write-Host "AD User Creation Job Starting (PowerShell)"
       Write-Host "AD Server: $ADServer"
@@ -290,153 +296,148 @@ resource "kubernetes_config_map_v1" "create_ad_user_script" {
       Write-Host "User DN: $UserDN"
       Write-Host "Method: Native AD PowerShell cmdlets"
       Write-Host "==============================================="
-      
+
       # Build credential object from environment variables
       $AdminPassword = ConvertTo-SecureString -String $env:ADMIN_PASSWORD -AsPlainText -Force
-      $AdminUsername = ($env:ADMIN_DN -replace 'CN=([^,]+),.*','$1')  # Extract username from DN
-      $DomainName = "mydomain"  # Domain name for credentials
+      $AdminUsername = ($env:ADMIN_DN -replace 'CN=([^,]+),.*','$1')
+      $DomainName = "mydomain"
       $Credential = New-Object System.Management.Automation.PSCredential("$DomainName\$AdminUsername", $AdminPassword)
-      
+
       Write-Host "Admin User: $DomainName\$AdminUsername"
-      
+
       # Wait for AD server to be ready
       Write-Host "Waiting for AD server to be ready..."
       $Connected = $false
       for ($i = 1; $i -le $MaxRetries; $i++) {
         try {
-          # Test connection using Test-NetConnection (built-in, no extra modules needed)
           $TestResult = Test-NetConnection -ComputerName $ADServer -Port 389 -InformationLevel Quiet -WarningAction SilentlyContinue
           if ($TestResult) {
-            Write-Host "✓ AD server is reachable on port 389"
+            Write-Host "AD server is reachable on port 389"
             $Connected = $true
             break
           }
         } catch {
           # Connection failed, will retry
         }
-        
+
         if ($i -eq $MaxRetries) {
-          Write-Host "✗ ERROR: AD server not reachable after $MaxRetries attempts"
+          Write-Host "ERROR: AD server not reachable after $MaxRetries attempts"
           Write-Host "Network debugging:"
-          Write-Host "- Testing DNS resolution:"
-          try { Resolve-DnsName $ADServer } catch { Write-Host "DNS resolution failed: $_" }
-          Write-Host "- Testing connectivity:"
+          try { Resolve-DnsName $ADServer } catch { Write-Host "DNS resolution failed" }
           Test-NetConnection -ComputerName $ADServer -Port 389 -InformationLevel Detailed
           exit 1
         }
-        
+
         Write-Host "Waiting for AD server... (attempt $i/$MaxRetries)"
         Start-Sleep -Seconds $RetryDelay
       }
-      
+
       # Additional wait for AD service to be fully initialized
       Write-Host "Waiting 10 seconds for AD service to fully initialize..."
       Start-Sleep -Seconds 10
-      
+
       # Import Active Directory module
       Write-Host "Loading Active Directory PowerShell module..."
       try {
         Import-Module ActiveDirectory -ErrorAction Stop
-        Write-Host "✓ Active Directory module loaded successfully"
+        Write-Host "Active Directory module loaded successfully"
       } catch {
-        Write-Host "✗ ERROR: Failed to load Active Directory module: $_"
-        Write-Host "This container may not have the AD PowerShell tools installed."
+        Write-Host "ERROR: Failed to load Active Directory module"
+        Write-Host $_.Exception.Message
         exit 1
       }
-      
+
       # Test AD authentication
       Write-Host "Testing AD authentication..."
       try {
-        # Try to query AD - this will fail if credentials are wrong
         $null = Get-ADDomain -Server $ADServer -Credential $Credential -ErrorAction Stop
-        Write-Host "✓ AD authentication successful"
+        Write-Host "AD authentication successful"
       } catch {
-        Write-Host "✗ ERROR: AD authentication failed: $_"
+        Write-Host "ERROR: AD authentication failed"
+        Write-Host $_.Exception.Message
         exit 1
       }
-      
+
       # Check if user already exists
       Write-Host "Checking if user $VaultUser already exists..."
       try {
         $ExistingUser = Get-ADUser -Identity $VaultUser -Server $ADServer -Credential $Credential -ErrorAction SilentlyContinue
         if ($ExistingUser) {
-          Write-Host "✓ User $VaultUser already exists - removing for fresh start (demo mode)"
+          Write-Host "User $VaultUser already exists - removing for fresh start (demo mode)"
           try {
             Remove-ADUser -Identity $VaultUser -Server $ADServer -Credential $Credential -Confirm:$false -ErrorAction Stop
-            Write-Host "✓ Existing user deleted successfully"
-            Start-Sleep -Seconds 2  # Give AD time to process deletion
+            Write-Host "Existing user deleted successfully"
+            Start-Sleep -Seconds 2
           } catch {
-            Write-Host "⚠ Warning: Failed to delete existing user: $_"
-            Write-Host "Will attempt to create anyway..."
+            Write-Host "Warning: Failed to delete existing user"
+            Write-Host $_.Exception.Message
           }
         } else {
-          Write-Host "✓ User $VaultUser does not exist, proceeding with creation"
+          Write-Host "User $VaultUser does not exist, proceeding with creation"
         }
       } catch {
-        Write-Host "✓ User $VaultUser does not exist, proceeding with creation"
+        Write-Host "User $VaultUser does not exist, proceeding with creation"
       }
-      
-      # Create user with password in one operation
+
+      # Create user with password
       Write-Host "Creating user $VaultUser with password..."
-      Write-Host "Note: Using New-ADUser cmdlet (native AD, no LDIF/LDAPS complexity)"
-      
       try {
         $SecurePassword = ConvertTo-SecureString -String $InitialPassword -AsPlainText -Force
-        
-        New-ADUser `
-          -Name $VaultUser `
-          -SamAccountName $VaultUser `
-          -UserPrincipalName "$VaultUser@mydomain.local" `
-          -DisplayName "Vault Demo Service Account" `
-          -Description "Service account managed by HashiCorp Vault for password rotation demo" `
-          -AccountPassword $SecurePassword `
-          -Enabled $true `
-          -PasswordNeverExpires $false `
-          -ChangePasswordAtLogon $false `
-          -Server $ADServer `
-          -Credential $Credential `
-          -Path "CN=Users,DC=mydomain,DC=local" `
-          -ErrorAction Stop
-        
-        Write-Host "✓ User created successfully with password and enabled"
+
+        $NewUserParams = @{
+          Name                  = $VaultUser
+          SamAccountName        = $VaultUser
+          UserPrincipalName     = "$VaultUser@mydomain.local"
+          DisplayName           = "Vault Demo Service Account"
+          Description           = "Service account managed by HashiCorp Vault for password rotation demo"
+          AccountPassword       = $SecurePassword
+          Enabled               = $true
+          PasswordNeverExpires  = $false
+          ChangePasswordAtLogon = $false
+          Server                = $ADServer
+          Credential            = $Credential
+          Path                  = "CN=Users,DC=mydomain,DC=local"
+          ErrorAction           = "Stop"
+        }
+        New-ADUser @NewUserParams
+
+        Write-Host "User created successfully with password and enabled"
       } catch {
-        Write-Host "✗ Failed to create user: $_"
-        Write-Host "Error details: $($_.Exception.Message)"
+        Write-Host "Failed to create user"
+        Write-Host $_.Exception.Message
         exit 1
       }
-      
+
       # Verify user was created
       Write-Host "Verifying user creation..."
       try {
         $CreatedUser = Get-ADUser -Identity $VaultUser -Server $ADServer -Credential $Credential -Properties Enabled,PasswordNeverExpires -ErrorAction Stop
-        Write-Host "✓ User verification successful"
-        Write-Host "  - SamAccountName: $($CreatedUser.SamAccountName)"
-        Write-Host "  - DistinguishedName: $($CreatedUser.DistinguishedName)"
-        Write-Host "  - Enabled: $($CreatedUser.Enabled)"
-        Write-Host "  - PasswordNeverExpires: $($CreatedUser.PasswordNeverExpires)"
+        Write-Host "User verification successful"
+        Write-Host ("  SamAccountName: " + $CreatedUser.SamAccountName)
+        Write-Host ("  DistinguishedName: " + $CreatedUser.DistinguishedName)
+        Write-Host ("  Enabled: " + $CreatedUser.Enabled)
+        Write-Host ("  PasswordNeverExpires: " + $CreatedUser.PasswordNeverExpires)
       } catch {
-        Write-Host "⚠ Warning: User verification failed: $_"
+        Write-Host "Warning: User verification failed"
+        Write-Host $_.Exception.Message
       }
-      
-      # Test user authentication (validates password is set correctly)
+
+      # Test user authentication
       Write-Host "Testing user authentication with new password..."
       try {
         $TestPassword = ConvertTo-SecureString -String $InitialPassword -AsPlainText -Force
         $TestCredential = New-Object System.Management.Automation.PSCredential("$DomainName\$VaultUser", $TestPassword)
-        
-        # Try to query AD with the new user's credentials
         $null = Get-ADDomain -Server $ADServer -Credential $TestCredential -ErrorAction Stop
-        Write-Host "✓ User authentication successful - password is working"
+        Write-Host "User authentication successful - password is working"
       } catch {
-        Write-Host "⚠ Warning: User authentication test failed: $_"
-        Write-Host "This may be normal if account needs time to replicate"
+        Write-Host "Warning: User authentication test failed (may need replication time)"
+        Write-Host $_.Exception.Message
       }
-      
+
       Write-Host "==============================================="
-      Write-Host "✓ AD User Creation Job Completed Successfully"
-      Write-Host "User: $VaultUser"
-      Write-Host "DN: $UserDN"
-      Write-Host "Initial password: $InitialPassword"
+      Write-Host "AD User Creation Job Completed Successfully"
+      Write-Host ("User: " + $VaultUser)
+      Write-Host ("DN: " + $UserDN)
       Write-Host "Note: This password will be rotated by Vault"
       Write-Host "==============================================="
     EOT
@@ -491,17 +492,37 @@ resource "kubernetes_job_v1" "create_ad_user" {
           name  = "create-ad-user"
           image = local.ad_tools_image
 
-          command = ["powershell", "-ExecutionPolicy", "Bypass", "-Command"]
-          args = [
-            <<-EOT
-              Write-Host "Starting AD user creation job..."
-              Write-Host "PowerShell Version: $($PSVersionTable.PSVersion)"
-              Write-Host "OS: $($PSVersionTable.OS)"
-              
-              # Execute the PowerShell script from ConfigMap
-              & C:\scripts\Create-ADUser.ps1
-            EOT
-          ]
+          command = ["powershell", "-ExecutionPolicy", "Bypass", "-File", "C:\\scripts\\Create-ADUser.ps1"]
+
+          env {
+            name = "AD_SERVER"
+            value_from {
+              secret_key_ref {
+                name = kubernetes_secret_v1.ldap_admin_creds.metadata[0].name
+                key  = "ad_server"
+              }
+            }
+          }
+
+          env {
+            name = "VAULT_USER"
+            value_from {
+              secret_key_ref {
+                name = kubernetes_secret_v1.ldap_admin_creds.metadata[0].name
+                key  = "vault_user"
+              }
+            }
+          }
+
+          env {
+            name = "INITIAL_PASSWORD"
+            value_from {
+              secret_key_ref {
+                name = kubernetes_secret_v1.ldap_admin_creds.metadata[0].name
+                key  = "initial_password"
+              }
+            }
+          }
 
           env {
             name = "ADMIN_DN"


### PR DESCRIPTION
## Summary

Fixes #95 — the create-ad-user job fails with PowerShell parse errors (`Missing closing }`, `The string is missing the terminator`, etc.)

## Root Cause

The AWS-generated Administrator password (`bVh2iyy2pq!wfmZbsW*f!R.WoPEF-cC7`) is interpolated directly into the PowerShell script via Terraform `${local.vault_demo_initial_password}` inside a `<<-EOT` heredoc. The `!` and `*` characters in the password corrupt PowerShell string parsing, causing cascading syntax errors.

## Changes

### 1. Quoted heredoc (`<<-'EOT'`)
The ConfigMap script now uses a **quoted heredoc** which disables all Terraform interpolation. No dynamic values are embedded in the script text.

### 2. All values via environment variables
Dynamic values (`AD_SERVER`, `VAULT_USER`, `INITIAL_PASSWORD`, `ADMIN_DN`, `ADMIN_PASSWORD`) are now passed as env vars from a Kubernetes Secret. The script reads them with `$env:*`.

### 3. Robust PowerShell patterns
- **Splatting hashtable** (`@{}`) replaces backtick line continuations for `New-ADUser` — more robust when scripts pass through heredocs/ConfigMaps
- **String concatenation** (`"text: " + $var`) replaces subexpressions (`"text: $($var.Prop)"`) in Write-Host calls
- **`-File` flag** replaces `-Command` with inline heredoc for cleaner script execution

### 4. Secret consolidation
The `ldap-admin-creds` Secret now stores all 5 values (was only 2), keeping everything in one place.