### PR TITLE
fix: replace hexagon with official Vault logo and fix credential display

### DIFF
--- a/.github/workflows/build-python-app-image.yml
+++ b/.github/workflows/build-python-app-image.yml
@@ -1,0 +1,47 @@
+name: Build Python App Image
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'python-app/**'
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository_owner }}/vault-ldap-demo
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=sha,prefix=
+            type=raw,value=latest
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: python-app
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/modules/kube2/4_ldap_app.tf
+++ b/modules/kube2/4_ldap_app.tf
@@ -4,7 +4,7 @@
 locals {
   ldap_app_name        = "ldap-credentials-app"
   ldap_app_secret_name = "ldap-credentials"
-  ldap_app_image       = "ghcr.io/andybaran/vault-ldap-demo:v1.1.0"
+  ldap_app_image       = "ghcr.io/andybaran/vault-ldap-demo:latest"
 }
 
 # VaultDynamicSecret CR for LDAP credentials

--- a/python-app/app.py
+++ b/python-app/app.py
@@ -334,8 +334,8 @@ HTML_TEMPLATE = """
         <!-- Header with Vault branding -->
         <div class="brand-header">
             <div class="brand-header-content">
-                <svg class="vault-logo" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
-                    <path fill="#FFD814" d="M50 10 L90 32.5 L90 67.5 L50 90 L10 67.5 L10 32.5 Z"/>
+                <svg class="vault-logo" viewBox="0 0 51 51" xmlns="http://www.w3.org/2000/svg">
+                    <path fill="#FFD814" fill-rule="nonzero" d="M0,0 L25.4070312,51 L51,0 L0,0 Z M28.5,10.5 L31.5,10.5 L31.5,13.5 L28.5,13.5 L28.5,10.5 Z M22.5,22.5 L19.5,22.5 L19.5,19.5 L22.5,19.5 L22.5,22.5 Z M22.5,18 L19.5,18 L19.5,15 L22.5,15 L22.5,18 Z M22.5,13.5 L19.5,13.5 L19.5,10.5 L22.5,10.5 L22.5,13.5 Z M26.991018,27 L24,27 L24,24 L27,24 L26.991018,27 Z M26.991018,22.5 L24,22.5 L24,19.5 L27,19.5 L26.991018,22.5 Z M26.991018,18 L24,18 L24,15 L27,15 L26.991018,18 Z M26.991018,13.5 L24,13.5 L24,10.5 L27,10.5 L26.991018,13.5 Z M28.5,15 L31.5,15 L31.5,18 L28.5089552,18 L28.5,15 Z M28.5,22.5 L28.5,19.5 L31.5,19.5 L31.5,22.4601182 L28.5,22.5 Z"/>
                 </svg>
                 <h1>Vault LDAP Credentials</h1>
             </div>


### PR DESCRIPTION
## Summary

Fixes #99

### Changes

1. **Replace yellow hexagon with official HashiCorp Vault logo** — The SVG in `python-app/app.py` was a simple yellow hexagon. Replaced it with the official Vault logo (triangular V with square grid pattern) sourced from the [hashicorp/vault](https://github.com/hashicorp/vault) repository.

2. **Fix DN and password not displaying** — The container image (`ghcr.io/andybaran/vault-ldap-demo:v1.1.0`) was outdated and didn't match the current `python-app/app.py` code. Updated to `:latest` tag which will be built from the current source.

3. **Add GitHub Actions workflow for Python app image** — Created `.github/workflows/build-python-app-image.yml` to automatically build and push the Python app image to `ghcr.io/andybaran/vault-ldap-demo:latest` on changes to `python-app/`.

### Files Changed
- `python-app/app.py` — Official Vault logo SVG
- `modules/kube2/4_ldap_app.tf` — Image tag `v1.1.0` → `latest`
- `.github/workflows/build-python-app-image.yml` — New workflow

### Note
After merging, the GitHub Actions workflow will build and push the new image. You may need to make the package public:
```
gh api --method PUT /user/packages/container/vault-ldap-demo/visibility -f visibility=public
```