### PR TITLE
fix: set userattr=cn for LDAP backend to fix user lookup

### DIFF
--- a/modules/vault_ldap_secrets/main.tf
+++ b/modules/vault_ldap_secrets/main.tf
@@ -12,6 +12,11 @@ resource "vault_ldap_secret_backend" "ad" {
   # Active Directory schema
   schema = "ad"
 
+  # Use CN to search for users — the default for AD schema is userPrincipalName,
+  # but Vault searches with the bare username (e.g., "vault-demo") which doesn't
+  # match the full UPN ("vault-demo@mydomain.local"), causing 0 results.
+  userattr = "cn"
+
   # User search base DN
   userdn = var.ldap_userdn
 


### PR DESCRIPTION
## Summary

Fixes #101

### Root Cause

When `schema = "ad"`, the Vault LDAP secrets engine defaults `userattr` to `userPrincipalName`. During password rotation, Vault searches with the **bare username** (`vault-demo`) as the filter value:

```
(userPrincipalName=vault-demo)
```

But the actual UPN in AD is `vault-demo@mydomain.local`, so the search returns 0 results:

```
expected one matching entry, but received 0
```

This was confirmed by reading the [Vault LDAP plugin source](https://github.com/hashicorp/vault-plugin-secrets-openldap/blob/main/client.go#L68-L76) and [path_config.go](https://github.com/hashicorp/vault-plugin-secrets-openldap/blob/main/path_config.go#L199-L201).

### Fix

Added `userattr = "cn"` to the LDAP backend config. The `cn` attribute matches the user's Common Name directly, which is always set to the bare username by the create-ad-user job.

### After merging

After applying, you'll need to manually trigger a rotation:
```bash
kubectl exec -it vault-0 -- vault write -f ldap/rotate-role/demo-service-account
```

Or wait for the next automatic rotation cycle.