### PR TITLE
fix: enable StartTLS for LDAP password rotation

### DIFF
--- a/modules/vault_ldap_secrets/main.tf
+++ b/modules/vault_ldap_secrets/main.tf
@@ -9,6 +9,12 @@ resource "vault_ldap_secret_backend" "ad" {
   bindpass = var.ldap_bindpass
   url      = var.ldap_url
 
+  # AD requires TLS for password modifications (LDAP Result Code 53 otherwise).
+  # StartTLS upgrades the plain LDAP connection to TLS on port 389.
+  # insecure_tls accepts the DC's self-signed certificate (demo only).
+  starttls     = true
+  insecure_tls = true
+
   # Active Directory schema
   schema = "ad"
 


### PR DESCRIPTION
## Summary

Fixes #103

### Root Cause

Active Directory **requires encrypted connections** for password modification operations. The current config uses plain `ldap://` without TLS, so AD rejects the password change with:

```
LDAP Result Code 53 "Unwilling To Perform": 0000001F: SvcErr: DSID-031A126C, problem 5003 (WILL_NOT_PERFORM)
```

This is a hard security requirement in AD — password changes are never allowed over unencrypted LDAP.

### Fix

Added two parameters to the `vault_ldap_secret_backend` config:

- `starttls = true` — upgrades the plain LDAP connection (port 389) to TLS
- `insecure_tls = true` — accepts the DC's self-signed certificate (appropriate for this demo)

### After merging

After applying, trigger a manual rotation to verify:
```bash
kubectl exec -it vault-0 -- vault write -f ldap/rotate-role/demo-service-account
```

Then check that credentials are populated:
```bash
kubectl exec -it vault-0 -- vault read ldap/static-cred/demo-service-account
```