### PR TITLE
feat: enable LDAPS via AD CS for Vault password rotation

### DIFF
--- a/components.tfcomponent.hcl
+++ b/components.tfcomponent.hcl
@@ -126,7 +126,7 @@ component "ldap" {
 component "vault_ldap_secrets" {
   source = "./modules/vault_ldap_secrets"
   inputs = {
-    ldap_url                = "ldap://${component.ldap.dc-priv-ip}"
+    ldap_url                = "ldaps://${component.ldap.dc-priv-ip}"
     ldap_binddn             = "CN=Administrator,CN=Users,DC=mydomain,DC=local"
     ldap_bindpass           = component.ldap.password
     ldap_userdn             = "CN=Users,DC=mydomain,DC=local"

--- a/modules/vault_ldap_secrets/main.tf
+++ b/modules/vault_ldap_secrets/main.tf
@@ -4,15 +4,14 @@ resource "vault_ldap_secret_backend" "ad" {
   path        = var.secrets_mount_path
   description = "LDAP secrets engine for Active Directory"
 
-  # LDAP connection settings
+  # LDAP connection settings — use LDAPS (port 636) for encrypted connection.
+  # AD requires TLS for password modifications; the DC has AD CS installed
+  # which auto-enrolls a certificate enabling LDAPS.
   binddn   = var.ldap_binddn
   bindpass = var.ldap_bindpass
   url      = var.ldap_url
 
-  # AD requires TLS for password modifications (LDAP Result Code 53 otherwise).
-  # StartTLS upgrades the plain LDAP connection to TLS on port 389.
-  # insecure_tls accepts the DC's self-signed certificate (demo only).
-  starttls     = true
+  # Accept the AD CS self-signed certificate (demo only)
   insecure_tls = true
 
   # Active Directory schema


### PR DESCRIPTION
## Summary

Fixes #105

### Root Cause

The DC has no TLS certificate, so both StartTLS and LDAPS fail:

```
LDAP Result Code 52 "Unavailable": Error initializing SSL/TLS
```

`Install-ADDSForest` does not configure TLS. AD requires encrypted connections for password modifications.

### Fix

**1. Install AD CS on the DC** (`modules/AWS_DC/main.tf`)

Added a scheduled task that runs after the post-promotion reboot to:
- Install `ADCS-Cert-Authority` Windows feature
- Configure an Enterprise Root CA (`Install-AdcsCertificationAuthority`)
- Restart NTDS so the DC picks up the new certificate
- Clean up the scheduled task

AD CS auto-enrolls a certificate for the DC, which enables LDAPS on port 636.

**2. Switch to LDAPS** (`modules/vault_ldap_secrets/main.tf` + `components.tfcomponent.hcl`)
- URL changed from `ldap://` to `ldaps://` (port 636)
- Removed `starttls = true` (not needed with native LDAPS)
- Kept `insecure_tls = true` to accept the AD CS self-signed cert

### ⚠️ Important: DC Rebuild Required

This changes the DC's `user_data`, which has `user_data_replace_on_change = true`. **The DC will be recreated** on next apply. This means:
- The AD user will need to be re-created (the create-ad-user job will run again)
- The Vault LDAP config will be updated with the new DC IP (if it changes)
- Allow extra time for the DC to boot, promote, reboot, and install AD CS before testing LDAPS