### PR TITLE
fix: move AD CS installation from DC user_data to create-ad-user job

### DIFF
--- a/modules/AWS_DC/main.tf
+++ b/modules/AWS_DC/main.tf
@@ -107,27 +107,7 @@ resource "aws_instance" "domain_controller" {
                   %{if var.only_kerberos~}
                     Set-ItemProperty  -Path "HKLM:\SYSTEM\CurrentControlSet\Control\Lsa\MSV1_0"  -Name RestrictSendingNTLMTraffic -Value 2 
                     Set-ItemProperty  -Path "HKLM:\SYSTEM\CurrentControlSet\Control\Lsa\MSV1_0"  -Name RestrictReceivingNTLMTraffic -Value 2 
-                  %{endif~}
-
-                  # Create a scheduled task to install AD CS after the post-promotion reboot.
-                  # AD CS auto-enrolls a certificate for the DC, enabling LDAPS on port 636.
-                  $AdcsScript = @'
-                  try {
-                    Install-WindowsFeature -Name ADCS-Cert-Authority -IncludeManagementTools
-                    Install-AdcsCertificationAuthority -CAType EnterpriseRootCA -CryptoProviderName "RSA#Microsoft Software Key Storage Provider" -KeyLength 2048 -HashAlgorithmName SHA256 -ValidityPeriod Years -ValidityPeriodUnits 5 -Force
-                    # Restart NTDS so the DC picks up the new certificate for LDAPS
-                    Restart-Service NTDS -Force
-                  } finally {
-                    Unregister-ScheduledTask -TaskName 'InstallADCS' -Confirm:$false
-                  }
-                  '@
-                  $AdcsScript | Out-File -FilePath C:\InstallADCS.ps1 -Encoding ASCII
-
-                  $Action  = New-ScheduledTaskAction -Execute 'powershell.exe' -Argument '-ExecutionPolicy Bypass -File C:\InstallADCS.ps1'
-                  $Trigger = New-ScheduledTaskTrigger -AtStartup
-                  $Principal = New-ScheduledTaskPrincipal -UserId 'SYSTEM' -LogonType ServiceAccount -RunLevel Highest
-                  Register-ScheduledTask -TaskName 'InstallADCS' -Action $Action -Trigger $Trigger -Principal $Principal -Description 'Install AD CS after domain promotion reboot'
-
+                  %{endif~}    
                   Install-ADDSForest -CreateDnsDelegation:$false -DomainMode Win2012R2 -DomainName ${var.active_directory_domain} -DomainNetbiosName ${var.active_directory_netbios_name} -ForestMode Win2012R2 -InstallDns:$true -SafeModeAdministratorPassword $password -Force:$true
                 </powershell>
               EOF

--- a/modules/windows_config/scripts/Create-ADUser.ps1
+++ b/modules/windows_config/scripts/Create-ADUser.ps1
@@ -162,3 +162,77 @@ Write-Host ("User: " + $VaultUser)
 Write-Host ("DN: " + $UserDN)
 Write-Host "Note: This password will be rotated by Vault"
 Write-Host "==============================================="
+
+# ===============================================
+# Install AD CS on the domain controller to enable LDAPS (port 636).
+# Vault requires TLS for password modifications.
+# We use PowerShell remoting (WinRM) to run this on the DC itself.
+# ===============================================
+Write-Host ""
+Write-Host "==============================================="
+Write-Host "Installing AD Certificate Services on DC"
+Write-Host "==============================================="
+
+try {
+  # Enable WinRM TrustedHosts for the AD server
+  Set-Item WSMan:\localhost\Client\TrustedHosts -Value $ADServer -Force
+
+  $Session = New-PSSession -ComputerName $ADServer -Credential $Credential -ErrorAction Stop
+  Write-Host "Remote session established to $ADServer"
+
+  $AdcsResult = Invoke-Command -Session $Session -ScriptBlock {
+    # Check if AD CS is already installed
+    $AdcsFeature = Get-WindowsFeature -Name ADCS-Cert-Authority
+    if ($AdcsFeature.Installed) {
+      Write-Host "AD CS already installed"
+      return "already_installed"
+    }
+
+    Write-Host "Installing ADCS-Cert-Authority feature..."
+    Install-WindowsFeature -Name ADCS-Cert-Authority -IncludeManagementTools -ErrorAction Stop
+
+    Write-Host "Configuring Enterprise Root CA..."
+    Install-AdcsCertificationAuthority `
+      -CAType EnterpriseRootCA `
+      -CryptoProviderName "RSA#Microsoft Software Key Storage Provider" `
+      -KeyLength 2048 `
+      -HashAlgorithmName SHA256 `
+      -ValidityPeriod Years `
+      -ValidityPeriodUnits 5 `
+      -Force `
+      -ErrorAction Stop
+
+    # Restart NTDS so the DC picks up the new certificate for LDAPS
+    Write-Host "Restarting NTDS service to enable LDAPS..."
+    Restart-Service NTDS -Force
+
+    return "installed"
+  } -ErrorAction Stop
+
+  if ($AdcsResult -eq "already_installed") {
+    Write-Host "AD CS was already configured on the DC"
+  } else {
+    Write-Host "AD CS installed and configured successfully"
+  }
+
+  # Verify LDAPS is working on port 636
+  Write-Host "Waiting 10 seconds for LDAPS to initialize..."
+  Start-Sleep -Seconds 10
+
+  $LdapsTest = Test-NetConnection -ComputerName $ADServer -Port 636 -InformationLevel Quiet -WarningAction SilentlyContinue
+  if ($LdapsTest) {
+    Write-Host "LDAPS (port 636) is reachable on $ADServer"
+  } else {
+    Write-Host "WARNING: LDAPS (port 636) is not yet reachable - it may need more time"
+  }
+
+  Remove-PSSession $Session
+} catch {
+  Write-Host "WARNING: Failed to install AD CS remotely"
+  Write-Host $_.Exception.Message
+  Write-Host "LDAPS may not be available - Vault password rotation may fail"
+}
+
+Write-Host "==============================================="
+Write-Host "All tasks completed"
+Write-Host "==============================================="


### PR DESCRIPTION
## Summary

Follow-up to PR #106 — the AD CS scheduled task in user_data broke domain promotion (the DC never became a domain controller).

### Changes

**1. Revert `modules/AWS_DC/main.tf`** to the original working user_data (removes the broken AD CS scheduled task)

**2. Add AD CS remote installation to `Create-ADUser.ps1`**

After creating the vault-demo user, the script now uses PowerShell remoting (WinRM) to:
- Connect to the DC using admin credentials
- Install `ADCS-Cert-Authority` Windows feature
- Configure an Enterprise Root CA (`Install-AdcsCertificationAuthority`)
- Restart NTDS so the DC picks up the new certificate for LDAPS on port 636
- Verify LDAPS connectivity

This approach is better because:
- The DC user_data remains simple and proven
- AD CS is installed after the DC is fully promoted and functional
- The create-ad-user job already has the credentials and AD connectivity needed
- If AD CS installation fails, it logs a warning but doesn't block user creation

### ⚠️ Note
Since user_data is being reverted, `user_data_replace_on_change = true` will trigger a DC rebuild. The create-ad-user job should re-run because the DC IP change cascades through the dependency chain.