### PR TITLE
fix: replace replace_triggered_by with DC IP annotation (#111)

### DIFF
--- a/modules/windows_config/main.tf
+++ b/modules/windows_config/main.tf
@@ -291,6 +291,12 @@ resource "kubernetes_job_v1" "create_ad_user" {
   metadata {
     name      = "create-ad-user"
     namespace = var.kube_namespace
+    annotations = {
+      # Force job re-creation when the DC is rebuilt — the private IP changes
+      # on each new instance, so a change here triggers Terraform to destroy
+      # the old completed job and create a new one.
+      "demo/dc-private-ip" = var.ldap_dc_private_ip
+    }
   }
 
   wait_for_completion = true
@@ -298,10 +304,6 @@ resource "kubernetes_job_v1" "create_ad_user" {
   timeouts {
     create = "20m"
     update = "20m"
-  }
-
-  lifecycle {
-    replace_triggered_by = [kubernetes_secret_v1.ldap_admin_creds]
   }
 
   spec {


### PR DESCRIPTION
## Summary

Fixes #111 — `replace_triggered_by` fails on a fresh Terraform state with:
```
Error: no change found for kubernetes_secret_v1.ldap_admin_creds in the root module
```

## Changes

Replaced `replace_triggered_by = [kubernetes_secret_v1.ldap_admin_creds]` with a `demo/dc-private-ip` annotation on the job metadata that holds the DC's private IP.

**Why this works:**
- On fresh deploy: the annotation is set with the DC IP, job is created normally
- On DC rebuild: the DC gets a new IP → annotation value changes → Kubernetes jobs are immutable → Terraform destroys the old job and creates a new one
- The vault-demo user is always created on the current DC