### PR TITLE
fix: resolve plan errors - null index and duplicate prefix (#116, #117)

### DIFF
--- a/components.tfcomponent.hcl
+++ b/components.tfcomponent.hcl
@@ -108,7 +108,6 @@ component "ldap" {
   source = "./modules/AWS_DC"
   inputs = {
     region                          = var.region
-    prefix                          = var.customer_name
     allowlist_ip                    = "66.190.197.168/32"
     vpc_id                          = component.kube0.vpc_id
     subnet_id                       = component.kube0.first_public_subnet_id

--- a/modules/ldap_app/ldap_app.tf
+++ b/modules/ldap_app/ldap_app.tf
@@ -231,5 +231,5 @@ output "ldap_app_service_type" {
 
 output "ldap_app_url" {
   description = "URL of the LDAP credentials app"
-  value       = "http://${kubernetes_service_v1.ldap_app.status[0].load_balancer[0].ingress[0].hostname}"
+  value       = "http://${try(kubernetes_service_v1.ldap_app.status[0].load_balancer[0].ingress[0].hostname, "pending")}"
 }


### PR DESCRIPTION
## Changes
- **`modules/ldap_app/ldap_app.tf`**: Use `try()` with `"pending"` fallback for LoadBalancer hostname in `ldap_app_url` output — prevents null index error during plan phase
- **`components.tfcomponent.hcl`**: Remove duplicate `prefix = var.customer_name` in the `ldap` component; keep `prefix = component.kube0.resources_prefix`

## Issues
Fixes #116
Fixes #117

## Testing
These fixes resolve the blocking plan error that caused the latest stack run (stc-JuF1UjCZE3UR3Piq, sequence #12) to fail.