### PR TITLE
release: fix plan errors for stack deployment (#116, #117)

### DIFF
--- a/components.tfcomponent.hcl
+++ b/components.tfcomponent.hcl
@@ -108,7 +108,6 @@ component "ldap" {
   source = "./modules/AWS_DC"
   inputs = {
     region                          = var.region
-    prefix                          = var.customer_name
     allowlist_ip                    = "66.190.197.168/32"
     vpc_id                          = component.kube0.vpc_id
     subnet_id                       = component.kube0.first_public_subnet_id

--- a/modules/ldap_app/ldap_app.tf
+++ b/modules/ldap_app/ldap_app.tf
@@ -231,5 +231,5 @@ output "ldap_app_service_type" {
 
 output "ldap_app_url" {
   description = "URL of the LDAP credentials app"
-  value       = "http://${kubernetes_service_v1.ldap_app.status[0].load_balancer[0].ingress[0].hostname}"
+  value       = "http://${try(kubernetes_service_v1.ldap_app.status[0].load_balancer[0].ingress[0].hostname, "pending")}"
 }


### PR DESCRIPTION
## Release Notes
Merging develop → main to trigger stack deployment with fixes:
- Fix null index error in `ldap_app_url` output (#116)
- Fix duplicate `prefix` input in ldap component (#117)

These were blocking the stack plan phase.