### PR TITLE
fix: add allowStaticCreds and refreshAfter to VaultDynamicSecret

### DIFF
--- a/modules/ldap_app/ldap_app.tf
+++ b/modules/ldap_app/ldap_app.tf
@@ -24,6 +24,12 @@ resource "kubernetes_manifest" "vault_ldap_secret" {
         name   = local.ldap_app_secret_name
         create = true
       }
+      # allowStaticCreds enables syncing of periodically rotated credentials
+      # (LDAP static roles) that have no lease TTL in the Vault response
+      allowStaticCreds = true
+      # refreshAfter tells VSO how often to re-sync the secret since
+      # static credentials don't include a lease duration
+      refreshAfter   = "8s"
       renewalPercent = 67
       vaultAuthRef   = var.vso_vault_auth_name
       rolloutRestartTargets = [


### PR DESCRIPTION
Fixes #120

## Changes
- Added `allowStaticCreds = true` to the VaultDynamicSecret spec — tells VSO these are periodically rotated LDAP static credentials
- Added `refreshAfter = "8s"` — sets the re-sync interval since static creds have no lease TTL

## Problem
VSO synced the LDAP credentials once on creation but never refreshed them. The VSO logs showed:
```
Vault secret does not support periodic renewal/refresh via reconciliation (requeue: false, horizon: 0)
```

The K8s secret had an empty password and `last_vault_rotation: 0001-01-01T00:00:00Z`.

## Verification
After this fix, VSO will re-sync the LDAP static credentials every 8 seconds, matching the 10-second rotation period. The LDAP app should display credentials that update with each rotation.