### PR TITLE
feat: increase rotation period to 30s and add refresh button

### DIFF
--- a/components.tfcomponent.hcl
+++ b/components.tfcomponent.hcl
@@ -60,6 +60,7 @@ component "ldap_app" {
     ldap_mount_path       = component.vault_ldap_secrets.ldap_secrets_mount_path
     ldap_static_role_name = component.vault_ldap_secrets.static_role_name
     vso_vault_auth_name   = component.vault_cluster.vso_vault_auth_name
+    static_role_rotation_period = 30
   }
   providers = {
     kubernetes = provider.kubernetes.this
@@ -137,7 +138,7 @@ component "vault_ldap_secrets" {
     kube_namespace          = component.kube1.kube_namespace
     # This dependency ensures the AD user creation job completes before Vault configures the LDAP secrets engine
     ad_user_job_completed   = component.windows_config.ad_user_job_status
-    static_role_rotation_period = 10
+    static_role_rotation_period = 30
   }
   providers = {
     vault = provider.vault.this

--- a/modules/ldap_app/ldap_app.tf
+++ b/modules/ldap_app/ldap_app.tf
@@ -28,8 +28,9 @@ resource "kubernetes_manifest" "vault_ldap_secret" {
       # (LDAP static roles) that have no lease TTL in the Vault response
       allowStaticCreds = true
       # refreshAfter tells VSO how often to re-sync the secret since
-      # static credentials don't include a lease duration
-      refreshAfter   = "8s"
+      # static credentials don't include a lease duration.
+      # Set to ~80% of the rotation period so VSO picks up changes promptly.
+      refreshAfter   = "${floor(var.static_role_rotation_period * 0.8)}s"
       renewalPercent = 67
       vaultAuthRef   = var.vso_vault_auth_name
       rolloutRestartTargets = [

--- a/modules/ldap_app/variables.tf
+++ b/modules/ldap_app/variables.tf
@@ -21,3 +21,9 @@ variable "vso_vault_auth_name" {
   type        = string
   default     = "default"
 }
+
+variable "static_role_rotation_period" {
+  description = "The LDAP static role rotation period in seconds. Used to derive the VSO refreshAfter interval."
+  type        = number
+  default     = 30
+}

--- a/python-app/app.py
+++ b/python-app/app.py
@@ -354,6 +354,37 @@ HTML_TEMPLATE = """
             text-decoration: underline;
         }
 
+        /* Refresh button - hidden until countdown expires + 5s */
+        .refresh-btn {
+            display: none;
+            margin-top: var(--spacing-400);
+            padding: var(--spacing-300) var(--spacing-600);
+            background: var(--color-vault);
+            color: var(--color-black);
+            border: none;
+            border-radius: var(--radius-medium);
+            font-family: var(--font-family-text);
+            font-size: var(--font-size-body-300);
+            font-weight: var(--font-weight-semibold);
+            cursor: pointer;
+            transition: all 0.2s ease;
+        }
+
+        .refresh-btn:hover {
+            background: #e6c200;
+            box-shadow: var(--elevation-mid);
+        }
+
+        .refresh-btn.visible {
+            display: inline-block;
+            animation: fadeIn 0.3s ease-in;
+        }
+
+        @keyframes fadeIn {
+            from { opacity: 0; transform: translateY(4px); }
+            to   { opacity: 1; transform: translateY(0); }
+        }
+
         @media (max-width: 640px) {
             body {
                 padding: var(--spacing-300);
@@ -407,6 +438,7 @@ HTML_TEMPLATE = """
                 <div class="countdown-bar-track">
                     <div class="countdown-bar-fill" id="countdown-bar" style="width: 100%"></div>
                 </div>
+                <button class="refresh-btn" id="refresh-btn" onclick="location.reload()">↻ Refresh Credentials</button>
             </div>
 
             <div class="credentials-grid">
@@ -456,6 +488,8 @@ HTML_TEMPLATE = """
             var pageLoadedAt = Date.now();
             var countdownEl = document.getElementById('countdown-seconds');
             var barEl = document.getElementById('countdown-bar');
+            var refreshBtn = document.getElementById('refresh-btn');
+            var buttonShown = false;
 
             function getRemaining() {
                 var elapsed = (Date.now() - pageLoadedAt) / 1000;
@@ -467,6 +501,14 @@ HTML_TEMPLATE = """
                 countdownEl.textContent = remaining;
                 var pct = rotationPeriod > 0 ? (remaining / rotationPeriod) * 100 : 0;
                 barEl.style.width = pct + '%';
+
+                // Show refresh button 5 seconds after countdown reaches 0
+                if (!buttonShown && remaining === 0) {
+                    buttonShown = true;
+                    setTimeout(function() {
+                        refreshBtn.classList.add('visible');
+                    }, 5000);
+                }
             }
 
             update();
@@ -485,7 +527,7 @@ def index():
         'username': os.getenv('LDAP_USERNAME', 'Not configured'),
         'password': os.getenv('LDAP_PASSWORD', 'Not configured'),
         'last_vault_password': os.getenv('LDAP_LAST_VAULT_PASSWORD', 'Not configured'),
-        'rotation_period': int(os.getenv('ROTATION_PERIOD', '10')),
+        'rotation_period': int(os.getenv('ROTATION_PERIOD', '30')),
         'rotation_ttl': int(os.getenv('ROTATION_TTL', '0')),
         'current_time': datetime.now().strftime('%Y-%m-%d %H:%M:%S UTC')
     }


### PR DESCRIPTION
Closes #123 Closes #124

## Changes

### Rotation Period (#123)
- Increased `static_role_rotation_period` from 10s to 30s in `components.tfcomponent.hcl`
- Added `static_role_rotation_period` variable to `ldap_app` module
- VSO `refreshAfter` now derives from the rotation period (80% = 24s for 30s period)
- Updated Python app default from 10s to 30s

### Refresh Button (#124)
- Added a "↻ Refresh Credentials" button to the countdown card
- Button is hidden during the countdown
- Appears with a fade-in animation 5 seconds after the countdown reaches 0
- Styled with HDS design tokens (Vault yellow background)
- Reloads the page to show updated credentials

### Files Changed
- `components.tfcomponent.hcl` — rotation period 10→30, added input to ldap_app component
- `modules/ldap_app/ldap_app.tf` — parameterized `refreshAfter`
- `modules/ldap_app/variables.tf` — new `static_role_rotation_period` variable
- `python-app/app.py` — refresh button CSS/HTML/JS, default period to 30

> **Note**: The Python app Docker image will be rebuilt automatically when this merges to main (GitHub Actions triggers on `python-app/**` changes).