### PR TITLE
chore: destroy stack resources

### DIFF
--- a/deployments.tfdeploy.hcl
+++ b/deployments.tfdeploy.hcl
@@ -22,5 +22,5 @@ deployment "development" {
     AWS_SECRET_ACCESS_KEY = store.varset.aws_creds.AWS_SECRET_ACCESS_KEY
     AWS_SESSION_TOKEN     = store.varset.aws_creds.AWS_SESSION_TOKEN
   }
-  #destroy = true
+  destroy = true
 }


### PR DESCRIPTION
Enable `destroy = true` in deployments.tfdeploy.hcl to tear down all AWS resources. Demo is complete.