### PR TITLE
fix: add removed block for admin_vm to unblock destroy

### DIFF
--- a/components.tfcomponent.hcl
+++ b/components.tfcomponent.hcl
@@ -1,4 +1,11 @@
 
+# admin_vm was removed — this block tells Stacks to destroy its state
+removed {
+  source = "./modules/admin_vm"
+
+  from = component.admin_vm
+}
+
 component "kube0" {
   source = "./modules/kube0"
   inputs = {

--- a/modules/admin_vm/main.tf
+++ b/modules/admin_vm/main.tf
@@ -1,0 +1,4 @@
+# Stub module — kept only so the `removed` block in components.tfcomponent.hcl
+# can reference this source while Stacks destroys the admin_vm state.
+# This file can be deleted once the destroy is complete and the removed block
+# is no longer needed.


### PR DESCRIPTION
The stack destroy failed with 'Unclaimed component instance' for admin_vm. Adds a `removed` block to `components.tfcomponent.hcl` and a stub module so Stacks can properly destroy the admin_vm state.