### PR TITLE
fix: add providers to removed block (develop → main)

### DIFF
--- a/components.tfcomponent.hcl
+++ b/components.tfcomponent.hcl
@@ -4,6 +4,10 @@ removed {
   source = "./modules/admin_vm"
 
   from = component.admin_vm
+
+  providers = {
+    aws = provider.aws.this
+  }
 }
 
 component "kube0" {

--- a/modules/admin_vm/main.tf
+++ b/modules/admin_vm/main.tf
@@ -2,3 +2,12 @@
 # can reference this source while Stacks destroys the admin_vm state.
 # This file can be deleted once the destroy is complete and the removed block
 # is no longer needed.
+
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.0"
+    }
+  }
+}


### PR DESCRIPTION
Adds provider assignments to the admin_vm removed block so Stacks can destroy its resources.