### PR TITLE
fix: add variable declarations to admin_vm stub for destroy

### DIFF
--- a/modules/admin_vm/variables.tf
+++ b/modules/admin_vm/variables.tf
@@ -1,0 +1,54 @@
+variable "vpc_id" {
+  type = string
+}
+
+variable "subnet_id" {
+  type = string
+}
+
+variable "instance_type" {
+  type = string
+}
+
+variable "allowlist_ip" {
+  type = string
+}
+
+variable "environment" {
+  type    = string
+  default = "dev"
+}
+
+variable "region" {
+  type = string
+}
+
+variable "eks_cluster_name" {
+  type = string
+}
+
+variable "vault_namespace" {
+  type = string
+}
+
+variable "vault_service_name" {
+  type    = string
+  default = "vault"
+}
+
+variable "shared_internal_sg_id" {
+  type = string
+}
+
+variable "prefix" {
+  type = string
+}
+
+variable "key_name" {
+  type = string
+}
+
+variable "ssh_private_key" {
+  type      = string
+  sensitive = true
+}


### PR DESCRIPTION
Stacks needs the stub module to declare all variables from state. Without them, destroy plan fails with 'Value assigned to undeclared variable' errors.