### PR TITLE
Remove Windows EKS nodes and windows_config; refactor vault_ldap_secrets for_each static roles

### DIFF
--- a/modules/kube0/1_aws_eks.tf
+++ b/modules/kube0/1_aws_eks.tf
@@ -24,12 +24,6 @@ module "eks" {
   # access to the IAM role that creates the cluster. No need for explicit
   # access_entries for the same role - that would cause a duplicate conflict.
 
-  # Additional IAM policies for cluster role
-  # AmazonEKSVPCResourceController is required for Windows support
-  iam_role_additional_policies = {
-    AmazonEKSVPCResourceController = "arn:aws:iam::aws:policy/AmazonEKSVPCResourceController"
-  }
-
   kms_key_administrators = [
     local.extra_doormat_role,
     data.aws_iam_session_context.current.issuer_arn,
@@ -46,9 +40,6 @@ module "eks" {
     }
     vpc-cni = {
       before_compute = true
-      # Note: Windows IPAM configuration via add-on configuration_values is not supported
-      # Windows networking may auto-configure when Windows nodes join, or may require
-      # manual post-deployment configuration if pods fail to get IPs
     }
     aws-ebs-csi-driver = {
       service_account_role_arn = aws_iam_role.ebs_csi_driver.arn
@@ -70,28 +61,6 @@ module "eks" {
       }
     }
 
-    # Windows nodes for AD user creation job
-    # Uses Windows Server 2022 Core (ltsc2022)
-    windows_nodes = {
-      ami_type       = "WINDOWS_CORE_2022_x86_64"
-      instance_types = ["t3.large"] # Windows requires minimum t3.large
-      min_size       = 1
-      max_size       = 2
-      desired_size   = 1
-
-      labels = {
-        workload = "windows"
-        os       = "windows"
-      }
-
-      taints = {
-        windows = {
-          key    = "os"
-          value  = "windows"
-          effect = "NO_SCHEDULE"
-        }
-      }
-    }
   }
 }
 

--- a/modules/vault_ldap_secrets/outputs.tf
+++ b/modules/vault_ldap_secrets/outputs.tf
@@ -8,14 +8,9 @@ output "ldap_secrets_mount_accessor" {
   value       = vault_ldap_secret_backend.ad.accessor
 }
 
-output "static_role_name" {
-  description = "The name of the LDAP static role"
-  value       = vault_ldap_secret_backend_static_role.service_account.role_name
-}
-
-output "static_role_credentials_path" {
-  description = "The full path to read static role credentials from Vault"
-  value       = "${vault_ldap_secret_backend.ad.path}/static-cred/${vault_ldap_secret_backend_static_role.service_account.role_name}"
+output "static_role_names" {
+  description = "Map of all LDAP static role names"
+  value       = { for k, v in vault_ldap_secret_backend_static_role.roles : k => v.role_name }
 }
 
 output "static_role_policy_name" {

--- a/modules/vault_ldap_secrets/variables.tf
+++ b/modules/vault_ldap_secrets/variables.tf
@@ -33,16 +33,13 @@ variable "active_directory_domain" {
   default     = "mydomain.local"
 }
 
-variable "static_role_name" {
-  description = "Name of the static role for password rotation"
-  type        = string
-  default     = "demo-service-account"
-}
-
-variable "static_role_username" {
-  description = "AD username for the static role (without domain)"
-  type        = string
-  default     = "vault-demo"
+variable "static_roles" {
+  description = "Map of static roles to create. Each key is the role name, value has username, password, and dn."
+  type = map(object({
+    username = string
+    password = string
+    dn       = string
+  }))
 }
 
 variable "static_role_rotation_period" {
@@ -63,10 +60,5 @@ variable "kubernetes_ca_cert" {
 
 variable "kube_namespace" {
   description = "Kubernetes namespace where VSO is deployed"
-  type        = string
-}
-
-variable "ad_user_job_completed" {
-  description = "Dependency marker to ensure AD user creation job completes before Vault LDAP secrets engine configuration"
   type        = string
 }


### PR DESCRIPTION
## Summary
Closes #149

The DC user_data script now creates AD test accounts during boot, so the Windows EKS node group and windows_config K8s jobs are no longer needed.

## Changes

### Removed
- **Windows node group** from `modules/kube0/1_aws_eks.tf` — saves a t3.large instance and eliminates ~10min Windows node boot wait
- **AmazonEKSVPCResourceController** IAM policy (only needed for Windows support)
- **`windows_config` component** and its dependency chain (`ad_user_job_completed`)

### Refactored
- **`vault_ldap_secrets` module** now accepts a `static_roles` map variable and creates Vault LDAP static roles via `for_each` instead of a single hardcoded role
- **Vault policy** updated from specific `static-cred/<role>` to wildcard `static-cred/*` to cover all roles
- **`ldap_app` component** now references `static_role_names["svc-rotate-a"]` from the map output

### Data flow
```
ldap (AWS_DC) → static_roles output → vault_ldap_secrets (for_each) → static_role_names → ldap_app (svc-rotate-a)
```

**Note:** The `modules/windows_config/` directory still exists but is no longer referenced by any component. It can be deleted in a follow-up cleanup.