### PR TITLE
Variablize Docker images for Vault and LDAP app

### DIFF
--- a/components.tfcomponent.hcl
+++ b/components.tfcomponent.hcl
@@ -45,6 +45,7 @@ component "ldap_app" {
     ldap_static_role_name = component.vault_ldap_secrets.static_role_names["svc-rotate-a"]
     vso_vault_auth_name   = component.vault_cluster.vso_vault_auth_name
     static_role_rotation_period = 30
+    ldap_app_image              = var.ldap_app_image
   }
   providers = {
     kubernetes = provider.kubernetes.this
@@ -56,8 +57,9 @@ component "ldap_app" {
 component "vault_cluster" {
   source = "./modules/vault"
   inputs = {
-    kube_namespace = component.kube1.kube_namespace
-
+    kube_namespace         = component.kube1.kube_namespace
+    vault_image_repository = var.vault_image_repository
+    vault_image_tag        = var.vault_image_tag
   }
   providers = {
     helm       = provider.helm.this

--- a/modules/ldap_app/ldap_app.tf
+++ b/modules/ldap_app/ldap_app.tf
@@ -4,7 +4,7 @@
 locals {
   ldap_app_name        = "ldap-credentials-app"
   ldap_app_secret_name = "ldap-credentials"
-  ldap_app_image       = "ghcr.io/andybaran/vault-ldap-demo:latest"
+  ldap_app_image       = var.ldap_app_image
 }
 
 # VaultDynamicSecret CR for LDAP credentials

--- a/modules/ldap_app/variables.tf
+++ b/modules/ldap_app/variables.tf
@@ -27,3 +27,9 @@ variable "static_role_rotation_period" {
   type        = number
   default     = 30
 }
+
+variable "ldap_app_image" {
+  description = "Docker image for the LDAP credentials display application"
+  type        = string
+  default     = "ghcr.io/andybaran/vault-ldap-demo:latest"
+}

--- a/modules/vault/variables.tf
+++ b/modules/vault/variables.tf
@@ -3,8 +3,14 @@ variable "kube_namespace" {
   type        = string
 }
 
-# variable "vault_license_key" {
-#   description = "The Vault Enterprise license key."
-#   type        = string
-#   sensitive = false 
-# }
+variable "vault_image_repository" {
+  description = "Docker image repository for Vault Enterprise"
+  type        = string
+  default     = "hashicorp/vault-enterprise"
+}
+
+variable "vault_image_tag" {
+  description = "Docker image tag for Vault Enterprise"
+  type        = string
+  default     = "1.21.2-ent"
+}

--- a/modules/vault/vault.tf
+++ b/modules/vault/vault.tf
@@ -40,11 +40,11 @@ resource "helm_release" "vault_cluster" {
     },
     {
       name  = "server.image.repository"
-      value = "hashicorp/vault-enterprise"
+      value = var.vault_image_repository
     },
     {
       name  = "server.image.tag"
-      value = "1.21.2-ent"
+      value = var.vault_image_tag
     },
     {
       name  = "server.enterpriseLicense.secretName"

--- a/modules/vault/vault_init.tf
+++ b/modules/vault/vault_init.tf
@@ -84,7 +84,7 @@ resource "kubernetes_job_v1" "vault_init" {
 
         container {
           name    = "vault-init"
-          image   = "hashicorp/vault-enterprise:1.21.2-ent"
+          image   = "${var.vault_image_repository}:${var.vault_image_tag}"
           command = ["/bin/sh", "-c"]
           args = [<<-EOT
             # Set Vault address to local pod

--- a/variables.tfcomponent.hcl
+++ b/variables.tfcomponent.hcl
@@ -67,3 +67,21 @@ variable "allowlist_ip" {
   type        = string
   default     = "0.0.0.0/0"
 }
+
+variable "vault_image_repository" {
+  description = "Docker image repository for Vault Enterprise"
+  type        = string
+  default     = "hashicorp/vault-enterprise"
+}
+
+variable "vault_image_tag" {
+  description = "Docker image tag for Vault Enterprise"
+  type        = string
+  default     = "1.21.2-ent"
+}
+
+variable "ldap_app_image" {
+  description = "Docker image for the LDAP credentials display application"
+  type        = string
+  default     = "ghcr.io/andybaran/vault-ldap-demo:latest"
+}


### PR DESCRIPTION
Closes #151

Extracts hardcoded Docker image references into stack-level variables so images can be overridden in `deployments.tfdeploy.hcl` without modifying module code.

### New stack-level variables
| Variable | Default | Used by |
|----------|---------|---------|
| `vault_image_repository` | `hashicorp/vault-enterprise` | vault Helm values + init job |
| `vault_image_tag` | `1.21.2-ent` | vault Helm values + init job |
| `ldap_app_image` | `ghcr.io/andybaran/vault-ldap-demo:latest` | ldap_app deployment |

### Files changed (8)
- `variables.tfcomponent.hcl` — 3 new variables
- `components.tfcomponent.hcl` — wire variables to vault_cluster and ldap_app
- `modules/vault/variables.tf` — declare `vault_image_repository`, `vault_image_tag`
- `modules/vault/vault.tf` — use variables in Helm set values
- `modules/vault/vault_init.tf` — use variables for init job image
- `modules/ldap_app/variables.tf` — declare `ldap_app_image`
- `modules/ldap_app/ldap_app.tf` — use variable in locals
- `.github/copilot-instructions.md` — updated codebase snapshot