### PR TITLE
Add 10-minute wait after DC creation for reboot cycle

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -46,7 +46,7 @@ The code currently utilizes **Terraform Stacks** and all work must continue to d
 
 ---
 
-## Codebase Snapshot (last updated: 2026-02-15, post PR #151)
+## Codebase Snapshot (last updated: 2026-02-15, post PR #153)
 
 ### Repository
 
@@ -131,9 +131,9 @@ kube0 (VPC, EKS, security groups)
 **Providers:** aws, tls, random
 
 **Files:**
-- `main.tf` — Windows Server 2022 EC2 (`data.aws_ami.windows_2022`), RSA-4096 keypair for RDP, security group (RDP + Kerberos from allowlist_ip), DSRM password via `random_string`, `random_password.test_user_password` (for_each over 4 test accounts), user_data PowerShell: first boot promotes to DC (`Install-ADDSForest`, domain `mydomain.local`), second boot installs AD CS (`Install-AdcsCertificationAuthority` for LDAPS) and creates test service accounts (svc-rotate-a, svc-rotate-b, svc-single, svc-lib). Elastic IP attached.
+- `main.tf` — Windows Server 2022 EC2 (`data.aws_ami.windows_2022`), RSA-4096 keypair for RDP, security group (RDP + Kerberos from allowlist_ip), DSRM password via `random_string`, `random_password.test_user_password` (for_each over 4 test accounts), user_data PowerShell: first boot promotes to DC (`Install-ADDSForest`, domain `mydomain.local`), second boot installs AD CS (`Install-AdcsCertificationAuthority` for LDAPS) and creates test service accounts (svc-rotate-a, svc-rotate-b, svc-single, svc-lib). Elastic IP attached. **`time_sleep.wait_for_dc_reboot` (10m) ensures reboot cycle completes before outputs become available.**
 - `variables.tf` — `allowlist_ip`, `prefix` (default "boundary-rdp"), `aws_key_pair_name`, `ami` (unused default), `domain_controller_instance_type`, `root_block_device_size` (128GB), `active_directory_domain` (mydomain.local), `active_directory_netbios_name` (mydomain), `only_ntlmv2`, `only_kerberos`, `vpc_id`, `subnet_id`, `shared_internal_sg_id`
-- `outputs.tf` — `private-key`, `public-dns-address`, `eip-public-ip`, `dc-priv-ip`, `password` (decrypted admin pw, nonsensitive), `aws_keypair_name`, `test_users` (map of test account details from `random_password`)
+- `outputs.tf` — `private-key`, `public-dns-address`, `eip-public-ip`, `dc-priv-ip`, `password` (decrypted admin pw, nonsensitive), `aws_keypair_name`, `static_roles` (map of test account username/password/dn from `random_password`). **All outputs depend on `time_sleep.wait_for_dc_reboot`.**
 - `README.md` — Documents the DC setup and PowerShell user_data
 
 #### `modules/windows_config/` — Windows IPAM + AD User Creation

--- a/modules/AWS_DC/main.tf
+++ b/modules/AWS_DC/main.tf
@@ -172,6 +172,15 @@ resource "aws_eip" "domain_controller_eip" {
   depends_on = [aws_instance.domain_controller]
 }
 
+# Wait for DC reboot after promotion
+# The DC reboots after Install-ADDSForest, then installs AD CS and creates
+# test users on the second boot. This takes approximately 10 minutes.
+resource "time_sleep" "wait_for_dc_reboot" {
+  depends_on = [aws_eip.domain_controller_eip]
+
+  create_duration = "10m"
+}
+
 locals {
   password = rsadecrypt(aws_instance.domain_controller.password_data, tls_private_key.rsa-4096-key.private_key_pem)
 }

--- a/modules/AWS_DC/outputs.tf
+++ b/modules/AWS_DC/outputs.tf
@@ -1,31 +1,37 @@
 // THIS IS NOT secure but we need the private key to retrieve the administrator password from AWS
 output "private-key" {
-  value = nonsensitive(tls_private_key.rsa-4096-key.private_key_pem)
+  value      = nonsensitive(tls_private_key.rsa-4096-key.private_key_pem)
+  depends_on = [time_sleep.wait_for_dc_reboot]
 }
 
 // This is the public DNS address of our instance (via Elastic IP)
 output "public-dns-address" {
-  value = aws_eip.domain_controller_eip.public_dns
+  value      = aws_eip.domain_controller_eip.public_dns
+  depends_on = [time_sleep.wait_for_dc_reboot]
 }
 
 // Elastic IP public address
 output "eip-public-ip" {
-  value = aws_eip.domain_controller_eip.public_ip
+  value      = aws_eip.domain_controller_eip.public_ip
+  depends_on = [time_sleep.wait_for_dc_reboot]
 }
 
 // Private IP address of the domain controller EC2 instance
 output "dc-priv-ip" {
-  value = aws_instance.domain_controller.private_ip
+  value      = aws_instance.domain_controller.private_ip
+  depends_on = [time_sleep.wait_for_dc_reboot]
 }
 
 // This is the decrypted administrator password for the EC2 instance
 output "password" {
-  value = nonsensitive(local.password)
+  value      = nonsensitive(local.password)
+  depends_on = [time_sleep.wait_for_dc_reboot]
 }
 
 // AWS Keypair name
 output "aws_keypair_name" {
-  value = aws_key_pair.rdp-key.key_name
+  value      = aws_key_pair.rdp-key.key_name
+  depends_on = [time_sleep.wait_for_dc_reboot]
 }
 
 output "static_roles" {
@@ -37,5 +43,6 @@ output "static_roles" {
       dn       = "CN=${name},CN=Users,DC=${join(",DC=", split(".", var.active_directory_domain))}"
     }
   }
-  sensitive = false
+  sensitive  = false
+  depends_on = [time_sleep.wait_for_dc_reboot]
 }


### PR DESCRIPTION
Closes #153

The Windows DC reboots after domain promotion (), then on second boot installs AD CS for LDAPS and creates the test service accounts. This full cycle takes approximately 10 minutes.

### Changes
- **Add ** resource in  with 10-minute duration
- **Make all AWS_DC outputs depend on the sleep** — ensures downstream resources (vault_ldap_secrets) wait for the full reboot cycle
- **Update copilot instructions** — document the time_sleep resource and fix `test_users` → `static_roles` in outputs description

### Flow
```
aws_instance.domain_controller → aws_eip → time_sleep (10m) → outputs → vault_ldap_secrets
```

Without this delay, `vault_ldap_secrets` could attempt to configure the LDAP engine before the DC is fully initialized, leading to connection failures.