### PR TITLE
Variablize LDAP app account name

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -46,7 +46,7 @@ The code currently utilizes **Terraform Stacks** and all work must continue to d
 
 ---
 
-## Codebase Snapshot (last updated: 2026-02-15, post PR #153)
+## Codebase Snapshot (last updated: 2026-02-15, post PR #155)
 
 ### Repository
 
@@ -61,7 +61,7 @@ The code currently utilizes **Terraform Stacks** and all work must continue to d
 | `components.tfcomponent.hcl` | Defines 6 stack components, their inputs/outputs, provider bindings, and dependency wiring |
 | `deployments.tfdeploy.hcl` | Single `development` deployment targeting `us-east-2`, references HCP Terraform varsets `varset-oUu39eyQUoDbmxE1` (aws_creds) and `varset-fMrcJCnqUd6q4D9C` (vault_license) |
 | `providers.tfcomponent.hcl` | All provider definitions with pinned versions |
-| `variables.tfcomponent.hcl` | Stack-level variable declarations (region, customer_name, AWS creds as ephemeral, vault_license_key, eks_node_ami_release_version, allowlist_ip, vault_image_repository, vault_image_tag, ldap_app_image) |
+| `variables.tfcomponent.hcl` | Stack-level variable declarations (region, customer_name, AWS creds as ephemeral, vault_license_key, eks_node_ami_release_version, allowlist_ip, vault_image_repository, vault_image_tag, ldap_app_image, ldap_app_account_name) |
 
 ### Provider Versions (pinned in `providers.tfcomponent.hcl`)
 
@@ -204,9 +204,10 @@ Flask app (`app.py`) displaying LDAP credentials:
 
 - **VPC CIDR:** 10.0.0.0/16
 - **AD Domain:** mydomain.local (NetBIOS: mydomain)
-- **AD User managed by Vault:** vault-demo
+- **AD Users managed by Vault:** svc-rotate-a, svc-rotate-b, svc-single, svc-lib (created by DC user_data)
+- **App displays account:** svc-rotate-a by default (configurable via `ldap_app_account_name` stack variable)
 - **LDAP bind DN:** CN=Administrator,CN=Users,DC=mydomain,DC=local
-- **Vault static role name:** demo-service-account
+- **Vault static role names:** match AD usernames (svc-rotate-a, svc-rotate-b, svc-single, svc-lib)
 - **VSO auth role:** vso-role (bound to SA `vso-auth`)
 - **VSO VaultAuth/VaultConnection names:** "default"
 - **Kubernetes auth path in Vault:** "kubernetes"

--- a/components.tfcomponent.hcl
+++ b/components.tfcomponent.hcl
@@ -42,7 +42,7 @@ component "ldap_app" {
   inputs = {
     kube_namespace        = component.kube1.kube_namespace
     ldap_mount_path       = component.vault_ldap_secrets.ldap_secrets_mount_path
-    ldap_static_role_name = component.vault_ldap_secrets.static_role_names["svc-rotate-a"]
+    ldap_static_role_name = component.vault_ldap_secrets.static_role_names[var.ldap_app_account_name]
     vso_vault_auth_name   = component.vault_cluster.vso_vault_auth_name
     static_role_rotation_period = 30
     ldap_app_image              = var.ldap_app_image

--- a/variables.tfcomponent.hcl
+++ b/variables.tfcomponent.hcl
@@ -85,3 +85,9 @@ variable "ldap_app_image" {
   type        = string
   default     = "ghcr.io/andybaran/vault-ldap-demo:latest"
 }
+
+variable "ldap_app_account_name" {
+  description = "AD service account name to display in the LDAP app (must exist in static_roles)"
+  type        = string
+  default     = "svc-rotate-a"
+}


### PR DESCRIPTION
Closes #155

Adds a stack-level variable to control which AD service account's credentials are displayed by the ldap_app component.

### New variable
- `ldap_app_account_name` (default: `"svc-rotate-a"`)

### Changes
- `variables.tfcomponent.hcl` — add `ldap_app_account_name` variable
- `components.tfcomponent.hcl` — use `static_role_names[var.ldap_app_account_name]` instead of hardcoded `"svc-rotate-a"`
- `.github/copilot-instructions.md` — update snapshot and fix outdated Key Configuration Values

### Usage
To display a different account in the app, override in `deployments.tfdeploy.hcl`:
```hcl
deployment "development" {
  inputs = {
    ldap_app_account_name = "svc-rotate-b"
    # ...
  }
}
```