### PR TITLE
Refactor vault_image variables to single vault_image

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -46,7 +46,7 @@ The code currently utilizes **Terraform Stacks** and all work must continue to d
 
 ---
 
-## Codebase Snapshot (last updated: 2026-02-15, post PR #155)
+## Codebase Snapshot (last updated: 2026-02-15, post PR #157)
 
 ### Repository
 
@@ -61,7 +61,7 @@ The code currently utilizes **Terraform Stacks** and all work must continue to d
 | `components.tfcomponent.hcl` | Defines 6 stack components, their inputs/outputs, provider bindings, and dependency wiring |
 | `deployments.tfdeploy.hcl` | Single `development` deployment targeting `us-east-2`, references HCP Terraform varsets `varset-oUu39eyQUoDbmxE1` (aws_creds) and `varset-fMrcJCnqUd6q4D9C` (vault_license) |
 | `providers.tfcomponent.hcl` | All provider definitions with pinned versions |
-| `variables.tfcomponent.hcl` | Stack-level variable declarations (region, customer_name, AWS creds as ephemeral, vault_license_key, eks_node_ami_release_version, allowlist_ip, vault_image_repository, vault_image_tag, ldap_app_image, ldap_app_account_name) |
+| `variables.tfcomponent.hcl` | Stack-level variable declarations (region, customer_name, AWS creds as ephemeral, vault_license_key, eks_node_ami_release_version, allowlist_ip, vault_image, ldap_app_image, ldap_app_account_name) |
 
 ### Provider Versions (pinned in `providers.tfcomponent.hcl`)
 
@@ -124,7 +124,7 @@ kube0 (VPC, EKS, security groups)
 - `vault_init.tf` — Init K8s job: downloads kubectl/jq, waits for vault-0, runs `vault operator init` (5 shares, 3 threshold), stores init JSON in `vault-init-data` K8s secret, unseals all 3 nodes, joins vault-1/vault-2 to Raft. Also handles re-unseal on already-initialized clusters. Uses RBAC (secret-writer SA, Role, RoleBinding).
 - `vso.tf` — VSO Helm chart v0.9.0, creates `VaultConnection` (name: `default`, uses Vault LB hostname), `VaultAuth` (name: `default`, K8s auth method, role `vso-role`, SA `vso-auth`, audience `vault`), `vso-auth` ServiceAccount with `system:auth-delegator` ClusterRoleBinding
 - `storage.tf` — `kubernetes_storage_class_v1.vault_storage`: EBS CSI gp3, encrypted, WaitForFirstConsumer
-- `variables.tf` — `kube_namespace`, `vault_image_repository` (default `hashicorp/vault-enterprise`), `vault_image_tag` (default `1.21.2-ent`)
+- `variables.tf` — `kube_namespace`, `vault_image` (default `hashicorp/vault-enterprise:1.21.2-ent`). Locals parse the image into `vault_repository` and `vault_tag` for Helm values.
 - `outputs.tf` — Reads `vault-init-data` secret, parses JSON for `root_token` and `unseal_keys_b64`. Outputs: `vault_unseal_keys` (sensitive), `vault_root_token` (nonsensitive!), `vault_namespace`, `vault_service_name` ("vault"), `vault_initialized`, `vault_loadbalancer_hostname` (http://LB:8200), `vault_ui_loadbalancer_hostname` (http://LB:8200), `vso_vault_auth_name` ("default")
 
 #### `modules/AWS_DC/` — Active Directory Domain Controller

--- a/components.tfcomponent.hcl
+++ b/components.tfcomponent.hcl
@@ -57,9 +57,8 @@ component "ldap_app" {
 component "vault_cluster" {
   source = "./modules/vault"
   inputs = {
-    kube_namespace         = component.kube1.kube_namespace
-    vault_image_repository = var.vault_image_repository
-    vault_image_tag        = var.vault_image_tag
+    kube_namespace = component.kube1.kube_namespace
+    vault_image    = var.vault_image
   }
   providers = {
     helm       = provider.helm.this

--- a/modules/vault/variables.tf
+++ b/modules/vault/variables.tf
@@ -3,14 +3,15 @@ variable "kube_namespace" {
   type        = string
 }
 
-variable "vault_image_repository" {
-  description = "Docker image repository for Vault Enterprise"
+variable "vault_image" {
+  description = "Docker image for Vault Enterprise (repository:tag)"
   type        = string
-  default     = "hashicorp/vault-enterprise"
+  default     = "hashicorp/vault-enterprise:1.21.2-ent"
 }
 
-variable "vault_image_tag" {
-  description = "Docker image tag for Vault Enterprise"
-  type        = string
-  default     = "1.21.2-ent"
+locals {
+  # Split the vault_image into repository and tag for Helm values
+  vault_image_parts = split(":", var.vault_image)
+  vault_repository  = local.vault_image_parts[0]
+  vault_tag         = length(local.vault_image_parts) > 1 ? local.vault_image_parts[1] : "latest"
 }

--- a/modules/vault/vault.tf
+++ b/modules/vault/vault.tf
@@ -40,11 +40,11 @@ resource "helm_release" "vault_cluster" {
     },
     {
       name  = "server.image.repository"
-      value = var.vault_image_repository
+      value = local.vault_repository
     },
     {
       name  = "server.image.tag"
-      value = var.vault_image_tag
+      value = local.vault_tag
     },
     {
       name  = "server.enterpriseLicense.secretName"

--- a/modules/vault/vault_init.tf
+++ b/modules/vault/vault_init.tf
@@ -84,7 +84,7 @@ resource "kubernetes_job_v1" "vault_init" {
 
         container {
           name    = "vault-init"
-          image   = "${var.vault_image_repository}:${var.vault_image_tag}"
+          image   = var.vault_image
           command = ["/bin/sh", "-c"]
           args = [<<-EOT
             # Set Vault address to local pod

--- a/variables.tfcomponent.hcl
+++ b/variables.tfcomponent.hcl
@@ -68,16 +68,10 @@ variable "allowlist_ip" {
   default     = "0.0.0.0/0"
 }
 
-variable "vault_image_repository" {
-  description = "Docker image repository for Vault Enterprise"
+variable "vault_image" {
+  description = "Docker image for Vault Enterprise (repository:tag)"
   type        = string
-  default     = "hashicorp/vault-enterprise"
-}
-
-variable "vault_image_tag" {
-  description = "Docker image tag for Vault Enterprise"
-  type        = string
-  default     = "1.21.2-ent"
+  default     = "hashicorp/vault-enterprise:1.21.2-ent"
 }
 
 variable "ldap_app_image" {


### PR DESCRIPTION
Closes #157

Combines `vault_image_repository` and `vault_image_tag` into a single `vault_image` variable containing the full image reference.

### Before
```hcl
vault_image_repository = "hashicorp/vault-enterprise"
vault_image_tag        = "1.21.2-ent"
```

### After
```hcl
vault_image = "hashicorp/vault-enterprise:1.21.2-ent"
```

### Changes
- **`variables.tfcomponent.hcl`** — replace two variables with single `vault_image`
- **`components.tfcomponent.hcl`** — pass single variable to vault_cluster component
- **`modules/vault/variables.tf`** — accept `vault_image`, add locals to parse into repository and tag
- **`modules/vault/vault.tf`** — use `local.vault_repository` and `local.vault_tag` in Helm values
- **`modules/vault/vault_init.tf`** — use `var.vault_image` directly
- **`.github/copilot-instructions.md`** — updated snapshot

### Benefits
- Simpler interface (1 variable instead of 2)
- Matches how Docker images are typically referenced
- Still supports custom images via deployment override