### PR TITLE
feat: add ldap_dual_account stack variable and wire through components

### DIFF
--- a/deployments.tfdeploy.hcl
+++ b/deployments.tfdeploy.hcl
@@ -17,6 +17,7 @@ deployment "development" {
     vault_license_key     = store.varset.vault_license.stable.vault_license_key
     eks_node_ami_release_version = "1.34.2-20260128"
     allowlist_ip                 = "66.190.197.168/32"
+    ldap_dual_account            = true
 
     #### Auth credentials for AWS
     AWS_ACCESS_KEY_ID     = store.varset.aws_creds.AWS_ACCESS_KEY_ID

--- a/variables.tfcomponent.hcl
+++ b/variables.tfcomponent.hcl
@@ -85,3 +85,15 @@ variable "ldap_app_account_name" {
   type        = string
   default     = "svc-rotate-a"
 }
+
+variable "ldap_dual_account" {
+  description = "Enable dual-account (blue/green) LDAP rotation using a custom Vault plugin. When true, uses a custom Vault image with the plugin and configures dual-account static roles."
+  type        = bool
+  default     = false
+}
+
+variable "grace_period" {
+  description = "Grace period in seconds for dual-account rotation (both credentials valid during this window). Must be less than rotation period."
+  type        = number
+  default     = 15
+}


### PR DESCRIPTION
## Summary
Adds `ldap_dual_account` (bool, default false) and `grace_period` (number, default 15) stack-level variables. Wires them through to `vault_cluster`, `vault_ldap_secrets`, and `ldap_app` components. Conditionally uses the custom Vault image when dual-account is enabled.

## Changes
- `variables.tfcomponent.hcl` — 2 new variables
- `components.tfcomponent.hcl` — conditional vault_image, new inputs wired to 3 components
- `deployments.tfdeploy.hcl` — `ldap_dual_account = true` for development deployment

## Codebase Snapshot Updates
- Added `ldap_dual_account` and `grace_period` to stack variables table
- vault_cluster component now conditionally uses custom image
- ldap_app component uses `dual-rotation-demo` role name when dual-account enabled

Closes #159