### PR TITLE
feat: add plugin_directory to Vault Helm config for custom plugin support

### DIFF
--- a/modules/vault/variables.tf
+++ b/modules/vault/variables.tf
@@ -9,6 +9,12 @@ variable "vault_image" {
   default     = "hashicorp/vault-enterprise:1.21.2-ent"
 }
 
+variable "ldap_dual_account" {
+  description = "Enable dual-account LDAP rotation. When true, configures plugin_directory in Vault for custom plugin support."
+  type        = bool
+  default     = false
+}
+
 locals {
   # Split the vault_image into repository and tag for Helm values
   vault_image_parts = split(":", var.vault_image)


### PR DESCRIPTION
## Summary
Adds `ldap_dual_account` variable to the vault module and conditionally configures `plugin_directory = "/vault/plugins"` in the Vault HA Raft config via Helm values. This allows Vault to find the custom plugin binary baked into the custom image.

## Changes
- `modules/vault/variables.tf` — new `ldap_dual_account` variable
- `modules/vault/vault.tf` — conditional `values` block with full HA Raft config including `plugin_directory`

## Technical Notes
- When `ldap_dual_account = false`: default Helm-generated config (no change)
- When `ldap_dual_account = true`: overrides `server.ha.raft.config` with the standard config + `plugin_directory = "/vault/plugins"`
- The custom image has the binary at `/vault/plugins/vault-plugin-secrets-openldap`

Closes #160