### PR TITLE
feat: configure dual-account LDAP secrets engine via Terraform

### DIFF
--- a/modules/vault_ldap_secrets/dual_account.tf
+++ b/modules/vault_ldap_secrets/dual_account.tf
@@ -1,0 +1,75 @@
+# Dual-Account (Blue/Green) LDAP Secrets Engine Configuration
+# These resources are only created when ldap_dual_account = true.
+# They register and configure a custom Vault plugin that supports
+# dual-account rotation with grace periods.
+
+# Register the custom plugin in Vault's plugin catalog
+resource "vault_generic_endpoint" "register_plugin" {
+  count = var.ldap_dual_account ? 1 : 0
+
+  path = "sys/plugins/catalog/secret/ldap_dual_account"
+
+  disable_read   = true
+  disable_delete = false
+
+  data_json = jsonencode({
+    sha256  = var.plugin_sha256
+    command = "vault-plugin-secrets-openldap"
+    version = "v0.17.0-dual-account.1"
+  })
+}
+
+# Mount the custom plugin as a secrets engine
+resource "vault_mount" "ldap_dual_account" {
+  count = var.ldap_dual_account ? 1 : 0
+
+  path        = var.secrets_mount_path
+  type        = "ldap_dual_account"
+  description = "Dual-account LDAP secrets engine for Active Directory"
+
+  depends_on = [vault_generic_endpoint.register_plugin]
+}
+
+# Configure the LDAP backend connection
+resource "vault_generic_endpoint" "ldap_config" {
+  count = var.ldap_dual_account ? 1 : 0
+
+  path = "${var.secrets_mount_path}/config"
+
+  disable_read   = true
+  disable_delete = true
+
+  data_json = jsonencode({
+    binddn       = var.ldap_binddn
+    bindpass     = var.ldap_bindpass
+    url          = var.ldap_url
+    schema       = "ad"
+    insecure_tls = true
+    userattr     = "cn"
+    userdn       = var.ldap_userdn
+  })
+
+  depends_on = [vault_mount.ldap_dual_account]
+}
+
+# Create dual-account static role with svc-rotate-a (primary) and svc-rotate-b (secondary)
+resource "vault_generic_endpoint" "ldap_dual_static_role" {
+  count = var.ldap_dual_account ? 1 : 0
+
+  path = "${var.secrets_mount_path}/static-role/${var.dual_account_static_role_name}"
+
+  disable_read   = true
+  disable_delete = false
+
+  data_json = jsonencode({
+    username          = "svc-rotate-a"
+    dn                = "CN=svc-rotate-a,CN=Users,DC=mydomain,DC=local"
+    username_b        = "svc-rotate-b"
+    dn_b              = "CN=svc-rotate-b,CN=Users,DC=mydomain,DC=local"
+    rotation_period   = "${var.static_role_rotation_period}s"
+    dual_account_mode = true
+    grace_period      = "${var.grace_period}s"
+  })
+
+  depends_on = [vault_generic_endpoint.ldap_config]
+}

--- a/modules/vault_ldap_secrets/outputs.tf
+++ b/modules/vault_ldap_secrets/outputs.tf
@@ -1,16 +1,18 @@
 output "ldap_secrets_mount_path" {
   description = "The mount path of the LDAP secrets engine"
-  value       = vault_ldap_secret_backend.ad.path
+  value       = var.secrets_mount_path
 }
 
 output "ldap_secrets_mount_accessor" {
   description = "The accessor of the LDAP secrets engine mount"
-  value       = vault_ldap_secret_backend.ad.accessor
+  value       = var.ldap_dual_account ? try(vault_mount.ldap_dual_account[0].accessor, "") : vault_ldap_secret_backend.ad[0].accessor
 }
 
 output "static_role_names" {
   description = "Map of all LDAP static role names"
-  value       = { for k, v in vault_ldap_secret_backend_static_role.roles : k => v.role_name }
+  value = var.ldap_dual_account ? {
+    (var.dual_account_static_role_name) = var.dual_account_static_role_name
+  } : { for k, v in vault_ldap_secret_backend_static_role.roles : k => v.role_name }
 }
 
 output "static_role_policy_name" {

--- a/modules/vault_ldap_secrets/variables.tf
+++ b/modules/vault_ldap_secrets/variables.tf
@@ -62,3 +62,27 @@ variable "kube_namespace" {
   description = "Kubernetes namespace where VSO is deployed"
   type        = string
 }
+
+variable "ldap_dual_account" {
+  description = "Enable dual-account (blue/green) LDAP rotation using a custom Vault plugin"
+  type        = bool
+  default     = false
+}
+
+variable "grace_period" {
+  description = "Grace period in seconds for dual-account rotation"
+  type        = number
+  default     = 15
+}
+
+variable "dual_account_static_role_name" {
+  description = "Name for the dual-account static role"
+  type        = string
+  default     = "dual-rotation-demo"
+}
+
+variable "plugin_sha256" {
+  description = "SHA256 hash of the custom Vault plugin binary"
+  type        = string
+  default     = "e71b4bec10963fe5f704d710f34be5a933330126799541fd1bd7b0e3536a8dad"
+}


### PR DESCRIPTION
## Summary
When `ldap_dual_account = true`, registers a custom Vault plugin (`ldap_dual_account`), mounts it as a secrets engine, configures the LDAP backend, and creates a dual-account static role with `svc-rotate-a`/`svc-rotate-b`. When false, existing behavior is unchanged.

## Changes
- `modules/vault_ldap_secrets/variables.tf` — 4 new variables (ldap_dual_account, grace_period, dual_account_static_role_name, plugin_sha256)
- `modules/vault_ldap_secrets/dual_account.tf` — **NEW** file with plugin registration, mount, config, and static role
- `modules/vault_ldap_secrets/main.tf` — count guards on single-account resources, decoupled policy from backend resource
- `modules/vault_ldap_secrets/outputs.tf` — conditional outputs for both modes

## Technical Details
- Plugin SHA256: `e71b4bec10963fe5f704d710f34be5a933330126799541fd1bd7b0e3536a8dad` (from custom image binary)
- Uses `vault_generic_endpoint` with `disable_read = true` for plugin catalog, config, and static role
- Uses `vault_mount` with `type = "ldap_dual_account"` for the secrets engine mount
- Dual-account static role: rotation_period=30s, grace_period=15s

## Dependencies
- Requires #164 (stack variables) and #165 (Vault Helm plugin_directory)

Closes #161