### PR TITLE
feat: add dual-account environment variables to ldap_app module

### DIFF
--- a/modules/ldap_app/ldap_app.tf
+++ b/modules/ldap_app/ldap_app.tf
@@ -184,6 +184,97 @@ resource "kubernetes_deployment_v1" "ldap_app" {
               }
             }
           }
+
+          # Dual-account mode environment variables
+          # These are only injected when ldap_dual_account is true.
+          # Fields like standby_username may not exist in the K8s secret
+          # during "active" state (only present during grace_period),
+          # so optional = true prevents pod startup failures.
+          dynamic "env" {
+            for_each = var.ldap_dual_account ? [1] : []
+            content {
+              name  = "DUAL_ACCOUNT_MODE"
+              value = "true"
+            }
+          }
+
+          dynamic "env" {
+            for_each = var.ldap_dual_account ? [1] : []
+            content {
+              name = "ACTIVE_ACCOUNT"
+              value_from {
+                secret_key_ref {
+                  name     = local.ldap_app_secret_name
+                  key      = "active_account"
+                  optional = true
+                }
+              }
+            }
+          }
+
+          dynamic "env" {
+            for_each = var.ldap_dual_account ? [1] : []
+            content {
+              name = "ROTATION_STATE"
+              value_from {
+                secret_key_ref {
+                  name     = local.ldap_app_secret_name
+                  key      = "rotation_state"
+                  optional = true
+                }
+              }
+            }
+          }
+
+          dynamic "env" {
+            for_each = var.ldap_dual_account ? [1] : []
+            content {
+              name = "STANDBY_USERNAME"
+              value_from {
+                secret_key_ref {
+                  name     = local.ldap_app_secret_name
+                  key      = "standby_username"
+                  optional = true
+                }
+              }
+            }
+          }
+
+          dynamic "env" {
+            for_each = var.ldap_dual_account ? [1] : []
+            content {
+              name = "STANDBY_PASSWORD"
+              value_from {
+                secret_key_ref {
+                  name     = local.ldap_app_secret_name
+                  key      = "standby_password"
+                  optional = true
+                }
+              }
+            }
+          }
+
+          dynamic "env" {
+            for_each = var.ldap_dual_account ? [1] : []
+            content {
+              name = "GRACE_PERIOD_END"
+              value_from {
+                secret_key_ref {
+                  name     = local.ldap_app_secret_name
+                  key      = "grace_period_end"
+                  optional = true
+                }
+              }
+            }
+          }
+
+          dynamic "env" {
+            for_each = var.ldap_dual_account ? [1] : []
+            content {
+              name  = "GRACE_PERIOD"
+              value = tostring(var.grace_period)
+            }
+          }
         }
       }
     }

--- a/modules/ldap_app/variables.tf
+++ b/modules/ldap_app/variables.tf
@@ -33,3 +33,15 @@ variable "ldap_app_image" {
   type        = string
   default     = "ghcr.io/andybaran/vault-ldap-demo:latest"
 }
+
+variable "ldap_dual_account" {
+  description = "Enable dual-account (blue/green) LDAP rotation display in the app"
+  type        = bool
+  default     = false
+}
+
+variable "grace_period" {
+  description = "Grace period in seconds for dual-account rotation"
+  type        = number
+  default     = 15
+}


### PR DESCRIPTION
## Summary
Adds conditional dual-account environment variables to the LDAP app K8s deployment. When `ldap_dual_account = true`, injects env vars for dual-account fields (DUAL_ACCOUNT_MODE, ACTIVE_ACCOUNT, ROTATION_STATE, STANDBY_USERNAME, STANDBY_PASSWORD, GRACE_PERIOD_END, GRACE_PERIOD) using `dynamic "env"` blocks. Uses `optional = true` on secret refs for fields that only exist during grace period.

## Changes
- `modules/ldap_app/variables.tf` — 2 new variables (ldap_dual_account, grace_period)
- `modules/ldap_app/ldap_app.tf` — 7 dynamic env blocks for dual-account mode

## Technical Notes
- During **active** state: standby_* fields absent from K8s secret → `optional = true` prevents pod failure
- During **grace_period**: all fields present, pod has full context
- VSO `rolloutRestartTargets` triggers pod restart on secret update, picking up state transitions

## Dependencies
- Requires #166 (dual-account LDAP secrets engine)

Closes #162