### PR TITLE
feat: add dual-account credential display to Python web app

### DIFF
--- a/python-app/app.py
+++ b/python-app/app.py
@@ -519,19 +519,779 @@ HTML_TEMPLATE = """
 </html>
 """
 
+# Dual-account (blue/green) HTML template
+DUAL_ACCOUNT_HTML_TEMPLATE = """
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Vault LDAP Credentials Demo - Dual Account</title>
+    <style>
+        /* HDS-inspired design tokens */
+        :root {
+            /* Colors - HashiCorp brand palette */
+            --color-vault: #FFD814;
+            --color-black: #000000;
+            --color-surface-primary: #FFFFFF;
+            --color-surface-secondary: #F7F8FA;
+            --color-surface-tertiary: #EBEEF2;
+            --color-surface-strong: #000000;
+            --color-foreground-primary: #1F2D3D;
+            --color-foreground-strong: #000000;
+            --color-foreground-faint: #5F6F84;
+            --color-foreground-success: #15834D;
+            --color-border-primary: #D9DEE5;
+            --color-border-strong: #A7B1BF;
+            --color-highlight: #5B3DE0;
+            --color-success: #15834D;
+            --color-success-surface: #DDF4E8;
+            --color-amber: #FFD814;
+            --color-amber-dark: #D4A500;
+            --color-amber-surface: #FFF8DC;
+
+            /* Typography - HDS font stack */
+            --font-family-text: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+            --font-family-code: "SF Mono", Monaco, "Cascadia Mono", "Roboto Mono", Consolas, "Courier New", monospace;
+
+            /* Typography scale */
+            --font-size-display-500: 30px;
+            --font-size-display-400: 24px;
+            --font-size-display-300: 20px;
+            --font-size-body-300: 16px;
+            --font-size-body-200: 14px;
+            --font-size-body-100: 12px;
+            --line-height-display: 1.2;
+            --line-height-body: 1.5;
+
+            /* Font weights */
+            --font-weight-regular: 400;
+            --font-weight-medium: 500;
+            --font-weight-semibold: 600;
+            --font-weight-bold: 700;
+
+            /* Spacing - HDS spacing scale */
+            --spacing-050: 2px;
+            --spacing-100: 4px;
+            --spacing-200: 8px;
+            --spacing-300: 12px;
+            --spacing-400: 16px;
+            --spacing-500: 24px;
+            --spacing-600: 32px;
+            --spacing-700: 40px;
+            --spacing-800: 48px;
+
+            /* Border radius */
+            --radius-small: 4px;
+            --radius-medium: 8px;
+            --radius-large: 12px;
+
+            /* Elevation */
+            --elevation-mid: 0 8px 16px rgba(31, 45, 61, 0.12);
+            --elevation-high: 0 12px 24px rgba(31, 45, 61, 0.16);
+        }
+
+        *, *::before, *::after {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: var(--font-family-text);
+            background-color: var(--color-surface-strong);
+            min-height: 100vh;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            padding: var(--spacing-500);
+            color: var(--color-foreground-primary);
+        }
+
+        .container {
+            background: var(--color-surface-primary);
+            border-radius: var(--radius-large);
+            box-shadow: var(--elevation-high);
+            max-width: 900px;
+            width: 100%;
+            overflow: hidden;
+        }
+
+        /* Header section with Vault branding */
+        .brand-header {
+            background: var(--color-black);
+            color: var(--color-surface-primary);
+            padding: var(--spacing-600) var(--spacing-700);
+            text-align: center;
+            border-bottom: 3px solid var(--color-vault);
+        }
+
+        .brand-header-content {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            gap: var(--spacing-400);
+            margin-bottom: var(--spacing-400);
+        }
+
+        .vault-logo {
+            width: 48px;
+            height: 48px;
+            flex-shrink: 0;
+        }
+
+        .brand-header h1 {
+            font-size: var(--font-size-display-400);
+            font-weight: var(--font-weight-semibold);
+            line-height: var(--line-height-display);
+            margin: 0;
+            color: var(--color-surface-primary);
+        }
+
+        .brand-header p {
+            font-size: var(--font-size-body-300);
+            color: var(--color-surface-tertiary);
+            margin: 0;
+            line-height: var(--line-height-body);
+        }
+
+        .status-badge {
+            display: inline-flex;
+            align-items: center;
+            gap: var(--spacing-100);
+            background: var(--color-success);
+            color: var(--color-surface-primary);
+            padding: var(--spacing-100) var(--spacing-300);
+            border-radius: var(--radius-large);
+            font-size: var(--font-size-body-100);
+            font-weight: var(--font-weight-semibold);
+            text-transform: uppercase;
+            letter-spacing: 0.5px;
+            margin-top: var(--spacing-300);
+        }
+
+        .status-badge::before {
+            content: '';
+            width: 8px;
+            height: 8px;
+            border-radius: 50%;
+            background: var(--color-surface-primary);
+            animation: pulse 2s ease-in-out infinite;
+        }
+
+        @keyframes pulse {
+            0%, 100% { opacity: 1; }
+            50% { opacity: 0.5; }
+        }
+
+        /* Main content area */
+        .content {
+            padding: var(--spacing-700);
+        }
+
+        .section-title {
+            font-size: var(--font-size-display-300);
+            font-weight: var(--font-weight-semibold);
+            color: var(--color-foreground-strong);
+            margin-bottom: var(--spacing-500);
+            padding-bottom: var(--spacing-300);
+            border-bottom: 2px solid var(--color-surface-tertiary);
+        }
+
+        .credentials-grid {
+            display: grid;
+            gap: var(--spacing-400);
+            margin-bottom: var(--spacing-600);
+        }
+
+        .credential-card {
+            background: var(--color-surface-secondary);
+            border: 1px solid var(--color-border-primary);
+            border-radius: var(--radius-medium);
+            padding: var(--spacing-500);
+            transition: all 0.2s ease;
+        }
+
+        .credential-card:hover {
+            border-color: var(--color-border-strong);
+            box-shadow: var(--elevation-mid);
+        }
+
+        .credential-label {
+            font-size: var(--font-size-body-100);
+            font-weight: var(--font-weight-semibold);
+            color: var(--color-foreground-faint);
+            text-transform: uppercase;
+            letter-spacing: 0.5px;
+            margin-bottom: var(--spacing-200);
+            display: flex;
+            align-items: center;
+            gap: var(--spacing-200);
+        }
+
+        .credential-label::before {
+            content: '';
+            width: 4px;
+            height: 12px;
+            background: var(--color-vault);
+            border-radius: 2px;
+        }
+
+        .credential-value {
+            font-family: var(--font-family-code);
+            font-size: var(--font-size-body-200);
+            color: var(--color-foreground-strong);
+            background: var(--color-surface-primary);
+            padding: var(--spacing-300);
+            border-radius: var(--radius-small);
+            border: 1px solid var(--color-border-primary);
+            word-break: break-all;
+            line-height: 1.6;
+        }
+
+        /* Countdown timer */
+        .countdown-card {
+            background: var(--color-surface-secondary);
+            border: 1px solid var(--color-border-primary);
+            border-radius: var(--radius-medium);
+            padding: var(--spacing-500);
+            margin-bottom: var(--spacing-600);
+            text-align: center;
+        }
+
+        .countdown-label {
+            font-size: var(--font-size-body-100);
+            font-weight: var(--font-weight-semibold);
+            color: var(--color-foreground-faint);
+            text-transform: uppercase;
+            letter-spacing: 0.5px;
+            margin-bottom: var(--spacing-300);
+        }
+
+        .countdown-display {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            gap: var(--spacing-400);
+        }
+
+        .countdown-value {
+            font-family: var(--font-family-code);
+            font-size: var(--font-size-display-500);
+            font-weight: var(--font-weight-bold);
+            color: var(--color-foreground-strong);
+            min-width: 80px;
+        }
+
+        .countdown-unit {
+            font-size: var(--font-size-body-200);
+            color: var(--color-foreground-faint);
+            font-weight: var(--font-weight-medium);
+        }
+
+        .countdown-bar-track {
+            height: 6px;
+            background: var(--color-surface-tertiary);
+            border-radius: 3px;
+            margin-top: var(--spacing-400);
+            overflow: hidden;
+        }
+
+        .countdown-bar-fill {
+            height: 100%;
+            background: var(--color-vault);
+            border-radius: 3px;
+            transition: width 1s linear;
+        }
+
+        /* Info section */
+        .info-section {
+            background: var(--color-success-surface);
+            border: 1px solid rgba(21, 131, 77, 0.3);
+            border-radius: var(--radius-medium);
+            padding: var(--spacing-500);
+            margin-bottom: var(--spacing-500);
+        }
+
+        .info-section-title {
+            font-size: var(--font-size-body-300);
+            font-weight: var(--font-weight-semibold);
+            color: var(--color-success);
+            margin-bottom: var(--spacing-300);
+            display: flex;
+            align-items: center;
+            gap: var(--spacing-200);
+        }
+
+        .info-section p {
+            font-size: var(--font-size-body-200);
+            color: var(--color-foreground-primary);
+            line-height: var(--line-height-body);
+            margin: 0;
+        }
+
+        /* Metadata section */
+        .metadata {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            padding: var(--spacing-500);
+            background: var(--color-surface-secondary);
+            border-top: 1px solid var(--color-border-primary);
+            font-size: var(--font-size-body-200);
+            color: var(--color-foreground-faint);
+        }
+
+        .metadata strong {
+            color: var(--color-foreground-strong);
+            font-weight: var(--font-weight-medium);
+        }
+
+        .powered-by {
+            display: flex;
+            align-items: center;
+            gap: var(--spacing-200);
+        }
+
+        .powered-by a {
+            color: var(--color-highlight);
+            text-decoration: none;
+            font-weight: var(--font-weight-medium);
+            transition: color 0.2s ease;
+        }
+
+        .powered-by a:hover {
+            color: var(--color-foreground-strong);
+            text-decoration: underline;
+        }
+
+        /* Refresh button - hidden until countdown expires + 5s */
+        .refresh-btn {
+            display: none;
+            margin-top: var(--spacing-400);
+            padding: var(--spacing-300) var(--spacing-600);
+            background: var(--color-vault);
+            color: var(--color-black);
+            border: none;
+            border-radius: var(--radius-medium);
+            font-family: var(--font-family-text);
+            font-size: var(--font-size-body-300);
+            font-weight: var(--font-weight-semibold);
+            cursor: pointer;
+            transition: all 0.2s ease;
+        }
+
+        .refresh-btn:hover {
+            background: #e6c200;
+            box-shadow: var(--elevation-mid);
+        }
+
+        .refresh-btn.visible {
+            display: inline-block;
+            animation: fadeIn 0.3s ease-in;
+        }
+
+        @keyframes fadeIn {
+            from { opacity: 0; transform: translateY(4px); }
+            to   { opacity: 1; transform: translateY(0); }
+        }
+
+        /* Dual-account specific styles */
+        .state-badge {
+            display: inline-flex;
+            align-items: center;
+            gap: var(--spacing-200);
+            padding: var(--spacing-300) var(--spacing-500);
+            border-radius: var(--radius-large);
+            font-size: var(--font-size-body-300);
+            font-weight: var(--font-weight-bold);
+            text-transform: uppercase;
+            letter-spacing: 1px;
+            margin-bottom: var(--spacing-500);
+        }
+
+        .state-badge-active {
+            background: var(--color-success);
+            color: var(--color-surface-primary);
+        }
+
+        .state-badge-active::before {
+            content: '';
+            width: 12px;
+            height: 12px;
+            border-radius: 50%;
+            background: var(--color-surface-primary);
+        }
+
+        .state-badge-grace {
+            background: var(--color-amber);
+            color: var(--color-black);
+            animation: pulseGrace 1.5s ease-in-out infinite;
+        }
+
+        .state-badge-grace::before {
+            content: '';
+            width: 12px;
+            height: 12px;
+            border-radius: 50%;
+            background: var(--color-black);
+            animation: pulse 1s ease-in-out infinite;
+        }
+
+        @keyframes pulseGrace {
+            0%, 100% { box-shadow: 0 0 0 0 rgba(255, 216, 20, 0.4); }
+            50% { box-shadow: 0 0 0 8px rgba(255, 216, 20, 0); }
+        }
+
+        .account-card {
+            background: var(--color-surface-secondary);
+            border: 1px solid var(--color-border-primary);
+            border-radius: var(--radius-medium);
+            padding: var(--spacing-500);
+            margin-bottom: var(--spacing-500);
+            transition: all 0.2s ease;
+        }
+
+        .account-card:hover {
+            box-shadow: var(--elevation-mid);
+        }
+
+        .account-card-active {
+            border-left: 4px solid var(--color-success);
+        }
+
+        .account-card-standby {
+            border-left: 4px solid var(--color-amber);
+            background: var(--color-amber-surface);
+        }
+
+        .account-card-header {
+            font-size: var(--font-size-body-300);
+            font-weight: var(--font-weight-semibold);
+            color: var(--color-foreground-strong);
+            margin-bottom: var(--spacing-400);
+            display: flex;
+            align-items: center;
+            gap: var(--spacing-200);
+        }
+
+        .account-indicator {
+            display: inline-block;
+            width: 24px;
+            height: 24px;
+            border-radius: 50%;
+            text-align: center;
+            line-height: 24px;
+            font-size: var(--font-size-body-100);
+            font-weight: var(--font-weight-bold);
+        }
+
+        .account-indicator-active {
+            background: var(--color-success);
+            color: var(--color-surface-primary);
+        }
+
+        .account-indicator-standby {
+            background: var(--color-amber);
+            color: var(--color-black);
+        }
+
+        .account-credentials {
+            display: grid;
+            gap: var(--spacing-300);
+        }
+
+        .timers-section {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: var(--spacing-400);
+            margin-bottom: var(--spacing-600);
+        }
+
+        .timer-card {
+            background: var(--color-surface-secondary);
+            border: 1px solid var(--color-border-primary);
+            border-radius: var(--radius-medium);
+            padding: var(--spacing-500);
+            text-align: center;
+        }
+
+        .timer-card-grace {
+            border-color: var(--color-amber);
+            background: var(--color-amber-surface);
+        }
+
+        .timer-card-grace .countdown-bar-fill {
+            background: var(--color-amber);
+        }
+
+        .grace-ended-message {
+            color: var(--color-amber-dark);
+            font-weight: var(--font-weight-semibold);
+            font-size: var(--font-size-body-300);
+        }
+
+        @media (max-width: 640px) {
+            body {
+                padding: var(--spacing-300);
+            }
+
+            .brand-header {
+                padding: var(--spacing-500);
+            }
+
+            .brand-header h1 {
+                font-size: var(--font-size-display-300);
+            }
+
+            .content {
+                padding: var(--spacing-500);
+            }
+
+            .metadata {
+                flex-direction: column;
+                gap: var(--spacing-300);
+                text-align: center;
+            }
+
+            .timers-section {
+                grid-template-columns: 1fr;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <!-- Header with Vault branding -->
+        <div class="brand-header">
+            <div class="brand-header-content">
+                <svg class="vault-logo" viewBox="0 0 51 51" xmlns="http://www.w3.org/2000/svg">
+                    <path fill="#FFD814" fill-rule="nonzero" d="M0,0 L25.4070312,51 L51,0 L0,0 Z M28.5,10.5 L31.5,10.5 L31.5,13.5 L28.5,13.5 L28.5,10.5 Z M22.5,22.5 L19.5,22.5 L19.5,19.5 L22.5,19.5 L22.5,22.5 Z M22.5,18 L19.5,18 L19.5,15 L22.5,15 L22.5,18 Z M22.5,13.5 L19.5,13.5 L19.5,10.5 L22.5,10.5 L22.5,13.5 Z M26.991018,27 L24,27 L24,24 L27,24 L26.991018,27 Z M26.991018,22.5 L24,22.5 L24,19.5 L27,19.5 L26.991018,22.5 Z M26.991018,18 L24,18 L24,15 L27,15 L26.991018,18 Z M26.991018,13.5 L24,13.5 L24,10.5 L27,10.5 L26.991018,13.5 Z M28.5,15 L31.5,15 L31.5,18 L28.5089552,18 L28.5,15 Z M28.5,22.5 L28.5,19.5 L31.5,19.5 L31.5,22.4601182 L28.5,22.5 Z"/>
+                </svg>
+                <h1>Vault LDAP Credentials</h1>
+            </div>
+            <p>Dual-Account (Blue/Green) Credential Rotation</p>
+            <div class="status-badge">Live Demo</div>
+        </div>
+
+        <!-- Main content -->
+        <div class="content">
+            <!-- Rotation State Badge -->
+            <div style="text-align: center;">
+                {% if rotation_state == 'grace_period' %}
+                <div class="state-badge state-badge-grace">Grace Period</div>
+                {% else %}
+                <div class="state-badge state-badge-active">Active</div>
+                {% endif %}
+            </div>
+
+            <!-- Active Account Card -->
+            <div class="account-card account-card-active">
+                <div class="account-card-header">
+                    <span class="account-indicator account-indicator-active">{{ active_account|upper }}</span>
+                    Active Account (Account {{ active_account|upper }})
+                </div>
+                <div class="account-credentials">
+                    <div class="credential-card">
+                        <div class="credential-label">Username</div>
+                        <div class="credential-value">{{ username }}</div>
+                    </div>
+                    <div class="credential-card">
+                        <div class="credential-label">Password</div>
+                        <div class="credential-value">{{ password }}</div>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Standby Account Card (only during grace period) -->
+            {% if rotation_state == 'grace_period' %}
+            <div class="account-card account-card-standby">
+                <div class="account-card-header">
+                    <span class="account-indicator account-indicator-standby">{{ standby_account|upper }}</span>
+                    Standby Account (Account {{ standby_account|upper }})
+                </div>
+                <div class="account-credentials">
+                    <div class="credential-card">
+                        <div class="credential-label">Username</div>
+                        <div class="credential-value">{{ standby_username }}</div>
+                    </div>
+                    <div class="credential-card">
+                        <div class="credential-label">Password</div>
+                        <div class="credential-value">{{ standby_password }}</div>
+                    </div>
+                </div>
+            </div>
+            {% endif %}
+
+            <!-- Timers Section -->
+            <div class="timers-section">
+                {% if rotation_state == 'grace_period' %}
+                <!-- Grace Period Countdown -->
+                <div class="timer-card timer-card-grace" role="timer" aria-label="Grace period remaining">
+                    <div class="countdown-label">Grace Period Remaining</div>
+                    <div class="countdown-display">
+                        <span class="countdown-value" id="grace-countdown-seconds">--</span>
+                        <span class="countdown-unit">seconds</span>
+                    </div>
+                    <div class="countdown-bar-track">
+                        <div class="countdown-bar-fill" id="grace-countdown-bar" style="width: 100%"></div>
+                    </div>
+                    <div id="grace-ended-msg" class="grace-ended-message" style="display: none; margin-top: var(--spacing-300);">Grace period ended</div>
+                </div>
+                {% endif %}
+
+                <!-- Rotation Countdown -->
+                <div class="timer-card {% if rotation_state != 'grace_period' %}{% endif %}" role="timer" aria-label="Time until next credential rotation" {% if rotation_state != 'grace_period' %}style="grid-column: 1 / -1;"{% endif %}>
+                    <div class="countdown-label">Next Rotation In</div>
+                    <div class="countdown-display">
+                        <span class="countdown-value" id="countdown-seconds">--</span>
+                        <span class="countdown-unit">seconds</span>
+                    </div>
+                    <div class="countdown-bar-track">
+                        <div class="countdown-bar-fill" id="countdown-bar" style="width: 100%"></div>
+                    </div>
+                    <button class="refresh-btn" id="refresh-btn" onclick="location.reload()">↻ Refresh Credentials</button>
+                </div>
+            </div>
+
+            <div class="info-section">
+                <div class="info-section-title">How It Works</div>
+                <p>
+                    These credentials use dual-account (blue/green) rotation. Two AD service accounts are managed
+                    simultaneously. During rotation, the standby account's password is rotated and it becomes the
+                    new active account. Both credentials remain valid during the grace period, giving applications
+                    time to switch. After the grace period, only the active account is served.
+                </p>
+            </div>
+        </div>
+
+        <!-- Footer metadata -->
+        <div class="metadata">
+            <div><strong>Page loaded:</strong> {{ current_time }}</div>
+            <div class="powered-by">
+                Powered by
+                <a href="https://developer.hashicorp.com/vault" target="_blank">HashiCorp Vault</a>
+                +
+                <a href="https://developer.hashicorp.com/vault/docs/platform/k8s/vso" target="_blank">VSO</a>
+            </div>
+        </div>
+    </div>
+
+    <script>
+        (function() {
+            var rotationPeriod = {{ rotation_period }};
+            var ttlAtLoad = {{ rotation_ttl }};
+            var pageLoadedAt = Date.now();
+            var countdownEl = document.getElementById('countdown-seconds');
+            var barEl = document.getElementById('countdown-bar');
+            var refreshBtn = document.getElementById('refresh-btn');
+            var buttonShown = false;
+
+            // Grace period variables
+            var gracePeriodEnd = '{{ grace_period_end }}';
+            var gracePeriodDuration = {{ grace_period }};
+            var graceCountdownEl = document.getElementById('grace-countdown-seconds');
+            var graceBarEl = document.getElementById('grace-countdown-bar');
+            var graceEndedMsg = document.getElementById('grace-ended-msg');
+            var graceEnded = false;
+
+            function getRemaining() {
+                var elapsed = (Date.now() - pageLoadedAt) / 1000;
+                return Math.max(0, Math.ceil(ttlAtLoad - elapsed));
+            }
+
+            function getGraceRemaining() {
+                if (!gracePeriodEnd) return 0;
+                var endTime = new Date(gracePeriodEnd).getTime();
+                var remaining = (endTime - Date.now()) / 1000;
+                return Math.max(0, Math.ceil(remaining));
+            }
+
+            function update() {
+                var remaining = getRemaining();
+                countdownEl.textContent = remaining;
+                var pct = rotationPeriod > 0 ? (remaining / rotationPeriod) * 100 : 0;
+                barEl.style.width = pct + '%';
+
+                // Show refresh button 5 seconds after countdown reaches 0
+                if (!buttonShown && remaining === 0) {
+                    buttonShown = true;
+                    setTimeout(function() {
+                        refreshBtn.classList.add('visible');
+                    }, 5000);
+                }
+            }
+
+            function updateGrace() {
+                if (!graceCountdownEl) return;
+                var remaining = getGraceRemaining();
+                graceCountdownEl.textContent = remaining;
+                var pct = gracePeriodDuration > 0 ? (remaining / gracePeriodDuration) * 100 : 0;
+                graceBarEl.style.width = pct + '%';
+
+                // Show grace ended message when countdown reaches 0
+                if (!graceEnded && remaining === 0) {
+                    graceEnded = true;
+                    graceEndedMsg.style.display = 'block';
+                }
+            }
+
+            update();
+            updateGrace();
+            setInterval(function() {
+                update();
+                updateGrace();
+            }, 1000);
+        })();
+    </script>
+</body>
+</html>
+"""
+
 
 @app.route('/')
 def index():
-    """Display LDAP credentials from environment variables."""
-    credentials = {
-        'username': os.getenv('LDAP_USERNAME', 'Not configured'),
-        'password': os.getenv('LDAP_PASSWORD', 'Not configured'),
-        'last_vault_password': os.getenv('LDAP_LAST_VAULT_PASSWORD', 'Not configured'),
-        'rotation_period': int(os.getenv('ROTATION_PERIOD', '30')),
-        'rotation_ttl': int(os.getenv('ROTATION_TTL', '0')),
-        'current_time': datetime.now().strftime('%Y-%m-%d %H:%M:%S UTC')
-    }
-    return render_template_string(HTML_TEMPLATE, **credentials)
+    """Display LDAP credentials from environment variables.
+    
+    Supports two modes:
+    - Single-account mode (default): displays one set of rotating credentials
+    - Dual-account mode: displays active/standby accounts with grace period
+    """
+    # Check for dual-account mode
+    dual_account_mode = os.getenv('DUAL_ACCOUNT_MODE', '').lower() == 'true'
+    
+    if dual_account_mode:
+        # Dual-account mode
+        active_account = os.getenv('ACTIVE_ACCOUNT', 'a').lower()
+        standby_account = 'b' if active_account == 'a' else 'a'
+        rotation_state = os.getenv('ROTATION_STATE', 'active').lower()
+        
+        credentials = {
+            'username': os.getenv('LDAP_USERNAME', 'Not configured'),
+            'password': os.getenv('LDAP_PASSWORD', 'Not configured'),
+            'active_account': active_account,
+            'standby_account': standby_account,
+            'rotation_state': rotation_state,
+            'standby_username': os.getenv('STANDBY_USERNAME', ''),
+            'standby_password': os.getenv('STANDBY_PASSWORD', ''),
+            'grace_period_end': os.getenv('GRACE_PERIOD_END', ''),
+            'grace_period': int(os.getenv('GRACE_PERIOD', '0')),
+            'rotation_period': int(os.getenv('ROTATION_PERIOD', '30')),
+            'rotation_ttl': int(os.getenv('ROTATION_TTL', '0')),
+            'current_time': datetime.now().strftime('%Y-%m-%d %H:%M:%S UTC')
+        }
+        return render_template_string(DUAL_ACCOUNT_HTML_TEMPLATE, **credentials)
+    else:
+        # Single-account mode (original behavior)
+        credentials = {
+            'username': os.getenv('LDAP_USERNAME', 'Not configured'),
+            'password': os.getenv('LDAP_PASSWORD', 'Not configured'),
+            'last_vault_password': os.getenv('LDAP_LAST_VAULT_PASSWORD', 'Not configured'),
+            'rotation_period': int(os.getenv('ROTATION_PERIOD', '30')),
+            'rotation_ttl': int(os.getenv('ROTATION_TTL', '0')),
+            'current_time': datetime.now().strftime('%Y-%m-%d %H:%M:%S UTC')
+        }
+        return render_template_string(HTML_TEMPLATE, **credentials)
 
 
 @app.route('/health')


### PR DESCRIPTION
## Summary
Adds dual-account (blue/green) credential display to the Flask web app. Detects `DUAL_ACCOUNT_MODE` env var and renders a new UI showing active/standby accounts, rotation state badges, and grace period countdown. Single-account mode is completely unchanged (backward compatible).

## Changes
- `python-app/app.py` — new `DUAL_ACCOUNT_HTML_TEMPLATE`, dual-account detection logic, grace period countdown

## UI Features (dual-account mode)
- **Rotation State Badge**: green "Active" or amber pulsing "Grace Period"
- **Active Account Card**: green left border, shows username + password
- **Standby Account Card**: amber styling, only visible during grace period
- **Two Countdown Timers**: rotation countdown + grace period countdown (parses ISO timestamp)
- **Updated "How It Works"**: explains dual-account rotation with grace period

## Testing
- Set `DUAL_ACCOUNT_MODE=true` with env vars to test dual-account UI
- Leave unset or empty to verify single-account UI unchanged

Closes #163