### PR TITLE
feat: update rotation period to 300s and grace period to 60s

### DIFF
--- a/components.tfcomponent.hcl
+++ b/components.tfcomponent.hcl
@@ -84,7 +84,7 @@ component "vault_ldap_secrets" {
     kubernetes_ca_cert          = component.kube0.kube_cluster_certificate_authority_data
     kube_namespace              = component.kube1.kube_namespace
     static_roles                = component.ldap.static_roles
-    static_role_rotation_period = 30
+    static_role_rotation_period = 300
     ldap_dual_account           = var.ldap_dual_account
     grace_period                = var.grace_period
   }
@@ -100,7 +100,7 @@ component "ldap_app" {
     ldap_mount_path             = component.vault_ldap_secrets.ldap_secrets_mount_path
     ldap_static_role_name       = var.ldap_dual_account ? "dual-rotation-demo" : var.ldap_app_account_name
     vso_vault_auth_name         = component.vault_cluster.vso_vault_auth_name
-    static_role_rotation_period = 30
+    static_role_rotation_period = 300
     ldap_app_image              = var.ldap_app_image
     ldap_dual_account           = var.ldap_dual_account
     grace_period                = var.grace_period

--- a/variables.tfcomponent.hcl
+++ b/variables.tfcomponent.hcl
@@ -95,5 +95,5 @@ variable "ldap_dual_account" {
 variable "grace_period" {
   description = "Grace period in seconds for dual-account rotation (both credentials valid during this window). Must be less than rotation period."
   type        = number
-  default     = 15
+  default     = 60
 }


### PR DESCRIPTION
Increases timing defaults for more realistic demo cycles:
- rotation_period: 30s → 300s (5 minutes)
- grace_period: 15s → 60s (1 minute)

Fixes #169