### PR TITLE
feat: Refactor Python app for multi-delivery-method support (V2)

### DIFF
--- a/python-app/requirements.txt
+++ b/python-app/requirements.txt
@@ -1,3 +1,3 @@
 Flask==3.1.0
 Werkzeug==3.1.3
-requests==2.32.3
+hvac==2.3.0


### PR DESCRIPTION
## Summary

Refactors the Python web application to support all three Vault Kubernetes secret delivery methods.

### Changes

**Python App (`python-app/app.py`):**
- Replaced `requests`-based `VaultClient` with `hvac` library for Vault API interaction
- Added `SECRET_DELIVERY_METHOD` env var support for three modes:
  - `vault-secrets-operator` (default): Read from K8s Secret env vars
  - `vault-agent-sidecar`: Read from rendered file at `/vault/secrets/ldap-creds`
  - `vault-csi-driver`: Read from individual files in `/vault/secrets/`
- Added `FileCredentialCache` class with background refresh thread (5s interval)
- Added delivery method badge to both single-account and dual-account UI templates
- Bumped `APP_VERSION` to 3.0.0

**Dependencies (`requirements.txt`):**
- Replaced `requests==2.32.3` with `hvac==2.3.0`

### Testing
- App loads successfully with `python3 -c 'from app import app'`
- All existing routes (`/`, `/api/credentials`, `/health`) maintained

### Related Issues
Closes #175 Closes #176