### PR TITLE
feat: Vault Agent sidecar and CSI Driver deployments for V2 multi-delivery

### DIFF
--- a/components.tfcomponent.hcl
+++ b/components.tfcomponent.hcl
@@ -185,6 +185,18 @@ output "ldap_app_access_info" {
   type        = string
 }
 
+output "ldap_app_vault_agent_url" {
+  description = "URL of the Vault Agent sidecar LDAP app"
+  value       = component.ldap_app.ldap_app_vault_agent_url
+  type        = string
+}
+
+output "ldap_app_csi_url" {
+  description = "URL of the CSI Driver LDAP app"
+  value       = component.ldap_app.ldap_app_csi_url
+  type        = string
+}
+
 # output "vault_root_token" {
 #     description = "The Vault root token."
 #     value = component.vault_cluster.vault_root_token

--- a/modules/ldap_app/csi_app.tf
+++ b/modules/ldap_app/csi_app.tf
@@ -1,0 +1,230 @@
+# CSI Driver Deployment for LDAP Credentials
+# This deployment demonstrates LDAP static role credentials delivered via Secrets Store CSI Driver
+# Uses service account svc-lib
+
+locals {
+  csi_app_name = "ldap-app-csi"
+}
+
+# Service account for CSI Driver authentication
+resource "kubernetes_service_account_v1" "ldap_app_csi" {
+  count = var.ldap_dual_account ? 1 : 0
+
+  metadata {
+    name      = "ldap-app-csi"
+    namespace = var.kube_namespace
+  }
+  automount_service_account_token = true
+}
+
+# SecretProviderClass for LDAP credentials via Vault CSI provider
+resource "kubernetes_manifest" "ldap_csi_secret_provider" {
+  count = var.ldap_dual_account ? 1 : 0
+
+  manifest = {
+    apiVersion = "secrets-store.csi.x-k8s.io/v1"
+    kind       = "SecretProviderClass"
+    metadata = {
+      name      = "ldap-csi-credentials"
+      namespace = var.kube_namespace
+    }
+    spec = {
+      provider = "vault"
+      parameters = {
+        roleName     = "csi-app-role"
+        vaultAddress = "http://vault.${var.kube_namespace}.svc.cluster.local:8200"
+        objects = yamlencode([
+          {
+            objectName = "username"
+            secretPath = "ldap/static-cred/svc-lib"
+            secretKey  = "username"
+          },
+          {
+            objectName = "password"
+            secretPath = "ldap/static-cred/svc-lib"
+            secretKey  = "password"
+          },
+          {
+            objectName = "last_vault_rotation"
+            secretPath = "ldap/static-cred/svc-lib"
+            secretKey  = "last_vault_rotation"
+          },
+          {
+            objectName = "rotation_period"
+            secretPath = "ldap/static-cred/svc-lib"
+            secretKey  = "rotation_period"
+          },
+          {
+            objectName = "ttl"
+            secretPath = "ldap/static-cred/svc-lib"
+            secretKey  = "ttl"
+          }
+        ])
+      }
+    }
+  }
+
+  computed_fields = ["spec"]
+}
+
+# Deployment for CSI Driver LDAP credentials application
+resource "kubernetes_deployment_v1" "ldap_app_csi" {
+  count = var.ldap_dual_account ? 1 : 0
+
+  metadata {
+    name      = local.csi_app_name
+    namespace = var.kube_namespace
+    labels = {
+      app = local.csi_app_name
+    }
+  }
+
+  spec {
+    replicas = 1
+
+    strategy {
+      type = "RollingUpdate"
+      rolling_update {
+        max_unavailable = 1
+        max_surge       = 1
+      }
+    }
+
+    selector {
+      match_labels = {
+        app = local.csi_app_name
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          app = local.csi_app_name
+        }
+      }
+
+      spec {
+        service_account_name            = kubernetes_service_account_v1.ldap_app_csi[0].metadata[0].name
+        automount_service_account_token = true
+
+        # CSI volume for secrets from Vault
+        volume {
+          name = "vault-secrets"
+          csi {
+            driver    = "secrets-store.csi.k8s.io"
+            read_only = true
+            volume_attributes = {
+              secretProviderClass = "ldap-csi-credentials"
+            }
+          }
+        }
+
+        container {
+          name              = "ldap-app"
+          image             = var.ldap_app_image
+          image_pull_policy = "Always"
+
+          port {
+            container_port = 8080
+            name           = "http"
+          }
+
+          volume_mount {
+            name       = "vault-secrets"
+            mount_path = "/vault/secrets"
+            read_only  = true
+          }
+
+          resources {
+            limits = {
+              cpu    = "200m"
+              memory = "256Mi"
+            }
+            requests = {
+              cpu    = "100m"
+              memory = "128Mi"
+            }
+          }
+
+          liveness_probe {
+            http_get {
+              path   = "/health"
+              port   = 8080
+              scheme = "HTTP"
+            }
+            initial_delay_seconds = 10
+            period_seconds        = 10
+            timeout_seconds       = 5
+            failure_threshold     = 3
+          }
+
+          readiness_probe {
+            http_get {
+              path   = "/health"
+              port   = 8080
+              scheme = "HTTP"
+            }
+            initial_delay_seconds = 5
+            period_seconds        = 5
+            timeout_seconds       = 3
+            failure_threshold     = 3
+          }
+
+          env {
+            name  = "SECRET_DELIVERY_METHOD"
+            value = "vault-csi-driver"
+          }
+
+          env {
+            name  = "SECRETS_FILE_PATH"
+            value = "/vault/secrets"
+          }
+        }
+      }
+    }
+  }
+
+  lifecycle {
+    ignore_changes = [
+      spec[0].template[0].metadata[0].annotations,
+      metadata[0].annotations
+    ]
+    create_before_destroy = true
+  }
+
+  depends_on = [kubernetes_manifest.ldap_csi_secret_provider]
+}
+
+# Service for CSI Driver LDAP credentials application
+resource "kubernetes_service_v1" "ldap_app_csi" {
+  count = var.ldap_dual_account ? 1 : 0
+
+  metadata {
+    name      = local.csi_app_name
+    namespace = var.kube_namespace
+    labels = {
+      app = local.csi_app_name
+    }
+  }
+
+  spec {
+    type = "LoadBalancer"
+
+    port {
+      name        = "http"
+      port        = 80
+      target_port = 8080
+      protocol    = "TCP"
+    }
+
+    selector = {
+      app = local.csi_app_name
+    }
+  }
+}
+
+# Output the service information
+output "ldap_app_csi_url" {
+  description = "URL of the CSI Driver LDAP app"
+  value       = var.ldap_dual_account ? "http://${try(kubernetes_service_v1.ldap_app_csi[0].status[0].load_balancer[0].ingress[0].hostname, "pending")}" : ""
+}

--- a/modules/ldap_app/ldap_app.tf
+++ b/modules/ldap_app/ldap_app.tf
@@ -217,6 +217,11 @@ resource "kubernetes_deployment_v1" "ldap_app" {
             }
           }
 
+          env {
+            name  = "SECRET_DELIVERY_METHOD"
+            value = "vault-secrets-operator"
+          }
+
           # Dual-account mode environment variables
           # These are only injected when ldap_dual_account is true.
           # Fields like standby_username may not exist in the K8s secret

--- a/modules/ldap_app/variables.tf
+++ b/modules/ldap_app/variables.tf
@@ -51,3 +51,9 @@ variable "vault_app_auth_role" {
   type        = string
   default     = ""
 }
+
+variable "vault_agent_image" {
+  description = "Docker image for Vault Agent sidecar"
+  type        = string
+  default     = "hashicorp/vault:1.18.0"
+}

--- a/modules/ldap_app/vault_agent_app.tf
+++ b/modules/ldap_app/vault_agent_app.tf
@@ -1,0 +1,325 @@
+# Vault Agent Sidecar Deployment for LDAP Credentials
+# This deployment demonstrates LDAP static role credentials delivered via Vault Agent sidecar
+# Uses service account svc-single
+
+locals {
+  vault_agent_app_name = "ldap-app-vault-agent"
+}
+
+# Service account for Vault Agent authentication
+resource "kubernetes_service_account_v1" "ldap_app_vault_agent" {
+  count = var.ldap_dual_account ? 1 : 0
+
+  metadata {
+    name      = "ldap-app-vault-agent"
+    namespace = var.kube_namespace
+  }
+  automount_service_account_token = true
+}
+
+# ConfigMap containing Vault Agent configuration
+resource "kubernetes_config_map_v1" "vault_agent_config" {
+  count = var.ldap_dual_account ? 1 : 0
+
+  metadata {
+    name      = "vault-agent-config"
+    namespace = var.kube_namespace
+  }
+
+  data = {
+    "vault-agent-config.hcl" = <<-EOT
+      exit_after_auth = false
+      pid_file = "/home/vault/pidfile"
+
+      vault {
+        address = "http://vault.${var.kube_namespace}.svc.cluster.local:8200"
+      }
+
+      auto_auth {
+        method "kubernetes" {
+          mount_path = "auth/kubernetes"
+          config = {
+            role = "vault-agent-app-role"
+          }
+        }
+        sink "file" {
+          config = {
+            path = "/home/vault/.vault-token"
+          }
+        }
+      }
+
+      template_config {
+        static_secret_render_interval = "30s"
+      }
+
+      template {
+        contents = <<TMPL
+      LDAP_USERNAME={{ with secret "ldap/static-cred/svc-single" }}{{ .Data.username }}{{ end }}
+      LDAP_PASSWORD={{ with secret "ldap/static-cred/svc-single" }}{{ .Data.password }}{{ end }}
+      LDAP_LAST_VAULT_PASSWORD={{ with secret "ldap/static-cred/svc-single" }}{{ .Data.last_vault_rotation }}{{ end }}
+      ROTATION_PERIOD={{ with secret "ldap/static-cred/svc-single" }}{{ .Data.rotation_period }}{{ end }}
+      ROTATION_TTL={{ with secret "ldap/static-cred/svc-single" }}{{ .Data.ttl }}{{ end }}
+      TMPL
+        destination = "/vault/secrets/ldap-creds"
+      }
+    EOT
+
+    "vault-agent-init-config.hcl" = <<-EOT
+      exit_after_auth = true
+      pid_file = "/home/vault/pidfile"
+
+      vault {
+        address = "http://vault.${var.kube_namespace}.svc.cluster.local:8200"
+      }
+
+      auto_auth {
+        method "kubernetes" {
+          mount_path = "auth/kubernetes"
+          config = {
+            role = "vault-agent-app-role"
+          }
+        }
+        sink "file" {
+          config = {
+            path = "/home/vault/.vault-token"
+          }
+        }
+      }
+
+      template {
+        contents = <<TMPL
+      LDAP_USERNAME={{ with secret "ldap/static-cred/svc-single" }}{{ .Data.username }}{{ end }}
+      LDAP_PASSWORD={{ with secret "ldap/static-cred/svc-single" }}{{ .Data.password }}{{ end }}
+      LDAP_LAST_VAULT_PASSWORD={{ with secret "ldap/static-cred/svc-single" }}{{ .Data.last_vault_rotation }}{{ end }}
+      ROTATION_PERIOD={{ with secret "ldap/static-cred/svc-single" }}{{ .Data.rotation_period }}{{ end }}
+      ROTATION_TTL={{ with secret "ldap/static-cred/svc-single" }}{{ .Data.ttl }}{{ end }}
+      TMPL
+        destination = "/vault/secrets/ldap-creds"
+      }
+    EOT
+  }
+}
+
+# Deployment for Vault Agent sidecar LDAP credentials application
+resource "kubernetes_deployment_v1" "ldap_app_vault_agent" {
+  count = var.ldap_dual_account ? 1 : 0
+
+  metadata {
+    name      = local.vault_agent_app_name
+    namespace = var.kube_namespace
+    labels = {
+      app = local.vault_agent_app_name
+    }
+  }
+
+  spec {
+    replicas = 1
+
+    strategy {
+      type = "RollingUpdate"
+      rolling_update {
+        max_unavailable = 1
+        max_surge       = 1
+      }
+    }
+
+    selector {
+      match_labels = {
+        app = local.vault_agent_app_name
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          app = local.vault_agent_app_name
+        }
+      }
+
+      spec {
+        service_account_name            = kubernetes_service_account_v1.ldap_app_vault_agent[0].metadata[0].name
+        automount_service_account_token = true
+
+        # Shared volume for secrets rendered by Vault Agent
+        volume {
+          name = "vault-secrets"
+          empty_dir {}
+        }
+
+        # Vault Agent config volume
+        volume {
+          name = "vault-agent-config"
+          config_map {
+            name = kubernetes_config_map_v1.vault_agent_config[0].metadata[0].name
+          }
+        }
+
+        # Init container: Vault Agent in init mode to pre-render credentials
+        init_container {
+          name  = "vault-agent-init"
+          image = var.vault_agent_image
+
+          args = ["agent", "-config=/vault/config/vault-agent-init-config.hcl"]
+
+          volume_mount {
+            name       = "vault-secrets"
+            mount_path = "/vault/secrets"
+          }
+
+          volume_mount {
+            name       = "vault-agent-config"
+            mount_path = "/vault/config"
+            read_only  = true
+          }
+
+          resources {
+            limits = {
+              cpu    = "100m"
+              memory = "128Mi"
+            }
+            requests = {
+              cpu    = "50m"
+              memory = "64Mi"
+            }
+          }
+        }
+
+        # Sidecar container: Vault Agent for ongoing refresh
+        container {
+          name  = "vault-agent"
+          image = var.vault_agent_image
+
+          args = ["agent", "-config=/vault/config/vault-agent-config.hcl"]
+
+          volume_mount {
+            name       = "vault-secrets"
+            mount_path = "/vault/secrets"
+          }
+
+          volume_mount {
+            name       = "vault-agent-config"
+            mount_path = "/vault/config"
+            read_only  = true
+          }
+
+          resources {
+            limits = {
+              cpu    = "100m"
+              memory = "128Mi"
+            }
+            requests = {
+              cpu    = "50m"
+              memory = "64Mi"
+            }
+          }
+        }
+
+        # Application container
+        container {
+          name              = "ldap-app"
+          image             = var.ldap_app_image
+          image_pull_policy = "Always"
+
+          port {
+            container_port = 8080
+            name           = "http"
+          }
+
+          volume_mount {
+            name       = "vault-secrets"
+            mount_path = "/vault/secrets"
+            read_only  = true
+          }
+
+          resources {
+            limits = {
+              cpu    = "200m"
+              memory = "256Mi"
+            }
+            requests = {
+              cpu    = "100m"
+              memory = "128Mi"
+            }
+          }
+
+          liveness_probe {
+            http_get {
+              path   = "/health"
+              port   = 8080
+              scheme = "HTTP"
+            }
+            initial_delay_seconds = 10
+            period_seconds        = 10
+            timeout_seconds       = 5
+            failure_threshold     = 3
+          }
+
+          readiness_probe {
+            http_get {
+              path   = "/health"
+              port   = 8080
+              scheme = "HTTP"
+            }
+            initial_delay_seconds = 5
+            period_seconds        = 5
+            timeout_seconds       = 3
+            failure_threshold     = 3
+          }
+
+          env {
+            name  = "SECRET_DELIVERY_METHOD"
+            value = "vault-agent-sidecar"
+          }
+
+          env {
+            name  = "SECRETS_FILE_PATH"
+            value = "/vault/secrets/ldap-creds"
+          }
+        }
+      }
+    }
+  }
+
+  lifecycle {
+    ignore_changes = [
+      spec[0].template[0].metadata[0].annotations,
+      metadata[0].annotations
+    ]
+    create_before_destroy = true
+  }
+}
+
+# Service for Vault Agent sidecar LDAP credentials application
+resource "kubernetes_service_v1" "ldap_app_vault_agent" {
+  count = var.ldap_dual_account ? 1 : 0
+
+  metadata {
+    name      = local.vault_agent_app_name
+    namespace = var.kube_namespace
+    labels = {
+      app = local.vault_agent_app_name
+    }
+  }
+
+  spec {
+    type = "LoadBalancer"
+
+    port {
+      name        = "http"
+      port        = 80
+      target_port = 8080
+      protocol    = "TCP"
+    }
+
+    selector = {
+      app = local.vault_agent_app_name
+    }
+  }
+}
+
+# Output the service information
+output "ldap_app_vault_agent_url" {
+  description = "URL of the Vault Agent sidecar LDAP app"
+  value       = var.ldap_dual_account ? "http://${try(kubernetes_service_v1.ldap_app_vault_agent[0].status[0].load_balancer[0].ingress[0].hostname, "pending")}" : ""
+}

--- a/modules/vault/csi_driver.tf
+++ b/modules/vault/csi_driver.tf
@@ -1,0 +1,31 @@
+# Secrets Store CSI Driver
+# The Vault Helm chart has csi.enabled=true (Vault CSI Provider),
+# but the Secrets Store CSI Driver itself needs separate installation.
+# Reference: https://secrets-store-csi-driver.sigs.k8s.io/
+
+resource "helm_release" "secrets_store_csi_driver" {
+  count = var.ldap_dual_account ? 1 : 0
+
+  name       = "secrets-store-csi-driver"
+  repository = "https://kubernetes-sigs.github.io/secrets-store-csi-driver/charts"
+  chart      = "secrets-store-csi-driver"
+  namespace  = var.kube_namespace
+  version    = "1.4.7"
+
+  set {
+    name  = "syncSecret.enabled"
+    value = "true"
+  }
+
+  set {
+    name  = "enableSecretRotation"
+    value = "true"
+  }
+
+  set {
+    name  = "rotationPollInterval"
+    value = "30s"
+  }
+
+  depends_on = [helm_release.vault_cluster]
+}

--- a/modules/vault/vault.tf
+++ b/modules/vault/vault.tf
@@ -100,7 +100,7 @@ YAML
     },
     {
       name  = "injector.enabled"
-      value = "false"
+      value = "true"
     },
     {
       name  = "ingress.enabled"

--- a/modules/vault_ldap_secrets/kubernetes_auth.tf
+++ b/modules/vault_ldap_secrets/kubernetes_auth.tf
@@ -42,3 +42,29 @@ resource "vault_kubernetes_auth_backend_role" "ldap_app" {
   token_policies                   = [vault_policy.ldap_static_read.name]
   audience                         = "vault"
 }
+
+# Kubernetes auth backend role for Vault Agent sidecar deployment
+resource "vault_kubernetes_auth_backend_role" "vault_agent_app" {
+  count = var.ldap_dual_account ? 1 : 0
+
+  backend                          = vault_auth_backend.kubernetes.path
+  role_name                        = "vault-agent-app-role"
+  bound_service_account_names      = ["ldap-app-vault-agent"]
+  bound_service_account_namespaces = [var.kube_namespace]
+  token_ttl                        = 600
+  token_policies                   = [vault_policy.ldap_static_read.name]
+  audience                         = "vault"
+}
+
+# Kubernetes auth backend role for CSI Driver deployment
+resource "vault_kubernetes_auth_backend_role" "csi_app" {
+  count = var.ldap_dual_account ? 1 : 0
+
+  backend                          = vault_auth_backend.kubernetes.path
+  role_name                        = "csi-app-role"
+  bound_service_account_names      = ["ldap-app-csi"]
+  bound_service_account_namespaces = [var.kube_namespace]
+  token_ttl                        = 600
+  token_policies                   = [vault_policy.ldap_static_read.name]
+  audience                         = "vault"
+}


### PR DESCRIPTION
## Summary
Adds Terraform infrastructure for two new secret delivery methods alongside the existing VSO deployment:
- **Vault Agent Sidecar** (svc-single account) — manual sidecar with init container + agent config
- **CSI Driver** (svc-lib account) — Secrets Store CSI Driver volume mount

## Changes
### New files
- `modules/ldap_app/vault_agent_app.tf` — SA, ConfigMap, Deployment (init + sidecar + app), Service
- `modules/ldap_app/csi_app.tf` — SA, SecretProviderClass, Deployment (CSI volume), Service
- `modules/vault/csi_driver.tf` — Secrets Store CSI Driver Helm chart

### Modified files
- `modules/vault/vault.tf` — Enable Vault Agent Injector
- `modules/vault_ldap_secrets/dual_account.tf` — Add static roles for svc-single, svc-lib
- `modules/vault_ldap_secrets/kubernetes_auth.tf` — Add K8s auth roles for new SAs
- `modules/ldap_app/ldap_app.tf` — Add SECRET_DELIVERY_METHOD env var to VSO deployment
- `modules/ldap_app/variables.tf` — Add vault_agent_image variable
- `components.tfcomponent.hcl` — Add component outputs for new app URLs

### Safety
All new resources gated on `ldap_dual_account = true` (matching existing pattern).

Closes #177, closes #178, closes #179, closes #180