### PR TITLE
fix: use set attribute syntax for helm_release in Terraform Stacks

### DIFF
--- a/modules/vault/csi_driver.tf
+++ b/modules/vault/csi_driver.tf
@@ -12,20 +12,20 @@ resource "helm_release" "secrets_store_csi_driver" {
   namespace  = var.kube_namespace
   version    = "1.4.7"
 
-  set {
-    name  = "syncSecret.enabled"
-    value = "true"
-  }
-
-  set {
-    name  = "enableSecretRotation"
-    value = "true"
-  }
-
-  set {
-    name  = "rotationPollInterval"
-    value = "30s"
-  }
+  set = [
+    {
+      name  = "syncSecret.enabled"
+      value = "true"
+    },
+    {
+      name  = "enableSecretRotation"
+      value = "true"
+    },
+    {
+      name  = "rotationPollInterval"
+      value = "30s"
+    }
+  ]
 
   depends_on = [helm_release.vault_cluster]
 }


### PR DESCRIPTION
Terraform Stacks (1.14.x) doesn't support `set {}` block syntax in `helm_release`. Converts to `set = [{}]` list attribute syntax matching the existing pattern in `vault.tf`.

This was causing stack configuration failures (3 errors on `csi_driver.tf` lines 15, 20, 25).