### PR TITLE
fix: Make Vault LBs internet-facing for HCP Terraform access

### DIFF
--- a/modules/vault/vault.tf
+++ b/modules/vault/vault.tf
@@ -120,7 +120,7 @@ YAML
     },
     {
       name  = "server.service.annotations.service\\.beta\\.kubernetes\\.io/aws-load-balancer-scheme"
-      value = "internal"
+      value = "internet-facing"
     },
     {
       name  = "server.service.annotations.service\\.beta\\.kubernetes\\.io/aws-load-balancer-backend-protocol"
@@ -148,7 +148,7 @@ YAML
     },
     {
       name  = "ui.annotations.service\\.beta\\.kubernetes\\.io/aws-load-balancer-scheme"
-      value = "internal"
+      value = "internet-facing"
     }
 
   ]


### PR DESCRIPTION
## Problem

The Vault server and UI NLBs were configured with `aws-load-balancer-scheme: internal`, making them only reachable from within the VPC. HCP Terraform agents run outside the VPC, so they could not reach Vault to configure the vault provider during plan/apply phases. This caused:

```
Error: failed to configure Vault address
```

## Fix

Changed both the Vault server and UI load balancer schemes from `internal` to `internet-facing`. This allows HCP Terraform workers to connect to Vault for provider configuration.

This is acceptable for a demo environment. In production, you would use HCP Terraform agents deployed within the VPC or a VPN/peering solution.

## Changes

- `modules/vault/vault.tf`: Changed `server.service.annotations` and `ui.annotations` load balancer scheme to `internet-facing`

Closes #182