### PR TITLE
Fix Vault auth audience for Agent sidecar and CSI, expose root token

### DIFF
--- a/components.tfcomponent.hcl
+++ b/components.tfcomponent.hcl
@@ -164,7 +164,6 @@ output "vault_root_token" {
   description = "Vault root token"
   value       = component.vault_cluster.vault_root_token
   type        = string
-  sensitive   = true
 }
 
 output "vault_ldap_secrets_path" {

--- a/modules/ldap_app/csi_app.tf
+++ b/modules/ldap_app/csi_app.tf
@@ -33,6 +33,7 @@ resource "kubernetes_manifest" "ldap_csi_secret_provider" {
       parameters = {
         roleName     = "csi-app-role"
         vaultAddress = "http://vault.${var.kube_namespace}.svc.cluster.local:8200"
+        audience     = "vault"
         objects = yamlencode([
           {
             objectName = "username"

--- a/modules/ldap_app/vault_agent_app.tf
+++ b/modules/ldap_app/vault_agent_app.tf
@@ -39,7 +39,8 @@ resource "kubernetes_config_map_v1" "vault_agent_config" {
         method "kubernetes" {
           mount_path = "auth/kubernetes"
           config = {
-            role = "vault-agent-app-role"
+            role            = "vault-agent-app-role"
+            token_audiences = "vault"
           }
         }
         sink "file" {
@@ -77,7 +78,8 @@ resource "kubernetes_config_map_v1" "vault_agent_config" {
         method "kubernetes" {
           mount_path = "auth/kubernetes"
           config = {
-            role = "vault-agent-app-role"
+            role            = "vault-agent-app-role"
+            token_audiences = "vault"
           }
         }
         sink "file" {


### PR DESCRIPTION
## Problem
Both Vault Agent sidecar and CSI Driver pods fail with:
```
invalid audience (aud) claim: audience claim does not match any expected audience
```

The Vault K8s auth roles require audience `vault` but the clients were using the default EKS audience.

## Fix
- **Vault Agent**: Added `token_audiences = "vault"` to both init and sidecar auto_auth configs
- **CSI SecretProviderClass**: Added `audience = "vault"` to parameters
- **Root token output**: Removed `sensitive = true` so the value is displayed in deployment outputs

## Files Changed
- `modules/ldap_app/vault_agent_app.tf` — Vault Agent audience fix
- `modules/ldap_app/csi_app.tf` — CSI audience fix
- `components.tfcomponent.hcl` — vault_root_token output no longer sensitive