### PR TITLE
fix: add triggers to time_sleep for DC instance replacement

### DIFF
--- a/modules/AWS_DC/main.tf
+++ b/modules/AWS_DC/main.tf
@@ -323,6 +323,10 @@ resource "aws_eip" "domain_controller_eip" {
 resource "time_sleep" "wait_for_dc_reboot" {
   depends_on = [aws_eip.domain_controller_eip]
 
+  triggers = {
+    instance_id = aws_instance.domain_controller.id
+  }
+
   create_duration = local.dc_wait_duration
 }
 


### PR DESCRIPTION
## Problem
`time_sleep.wait_for_dc_reboot` lacks a `triggers` block, so it is NOT re-created when the EC2 domain controller is replaced. This causes `vault_ldap_secrets` to start immediately after instance replacement without waiting for AD promotion/LDAPS.

## Solution
Add `triggers = { instance_id = aws_instance.domain_controller.id }` so the sleep re-fires whenever the DC instance changes.

## Changes
- `modules/AWS_DC/main.tf`: Add `triggers` block to `time_sleep.wait_for_dc_reboot`